### PR TITLE
Fix: markup error in setup wizard

### DIFF
--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -572,8 +572,8 @@ async def run_setup_wizard() -> None:
     console.print("    - SciPy/NumPy: scientific computing")
     console.print("    - Lean 4: theorem proving (requires separate Lean install)")
     console.print("")
-    console.print("  [dim]Note: Z3 downloads a ~35MB binary. All packages have")
-    console.print("  pre-built wheels for Windows, macOS, and Linux.[/dim]")
+    console.print("  [dim]Note: Z3 downloads a ~35MB binary. All packages have[/dim]")
+    console.print("  [dim]pre-built wheels for Windows, macOS, and Linux.[/dim]")
 
     if Confirm.ask("\nInstall math features?", default=False):
         console.print("  Installing math dependencies...")


### PR DESCRIPTION
# Fix Rich Markup Error in Setup Wizard

Setup wizard crashed with a MarkupError: closing tag '[/dim]'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined text formatting in the math features notice for improved visual presentation and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->