### PR TITLE
Fix: Setup wizard fails when run directly as script

### DIFF
--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -20,6 +20,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+# Ensure project root is in sys.path for imports when run as a script
+# This handles both `python -m scripts.setup.wizard` and `python scripts/setup/wizard.py`
+_this_file = Path(__file__).resolve()
+_project_root = _this_file.parent.parent.parent  # scripts/setup/wizard.py -> opc/
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 try:
     from rich.console import Console
     from rich.panel import Panel


### PR DESCRIPTION
## Summary

- Fix import error when running wizard directly with `python scripts/setup/wizard.py`
- Add sys.path handling to ensure project root is always available

## Problem

When running the setup wizard directly as a script (instead of as a module), Python adds `scripts/setup/` to `sys.path` instead of the project root, causing:

```
Step 0/12: Backing up global Claude configuration...
Error: No module named 'scripts.setup'
```

## Solution

Added path handling at the top of `wizard.py` that resolves the project root and adds it to `sys.path` if not already present.

## Test plan

- [x] `python scripts/setup/wizard.py` - now works
- [x] `python -m scripts.setup.wizard` - still works  
- [x] `uv run python -m scripts.setup.wizard` - still works

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced reliability of the setup wizard script execution in different runtime environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->