### PR TITLE
fix: add CLAUDE_OPC_DIR env var support for global hook installation

### DIFF
--- a/.claude/hooks/src/memory-awareness.ts
+++ b/.claude/hooks/src/memory-awareness.ts
@@ -13,7 +13,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { spawnSync } from 'child_process';
-import { join } from 'path';
+import { getOpcDir } from './shared/opc-path.js';
 
 interface UserPromptSubmitInput {
   session_id: string;
@@ -108,7 +108,8 @@ function extractKeywords(prompt: string): string {
 function checkMemoryRelevance(intent: string, projectDir: string): MemoryMatch | null {
   if (!intent || intent.length < 3) return null;
 
-  const opcDir = join(projectDir, 'opc');
+  const opcDir = getOpcDir();
+  if (!opcDir) return null;  // Graceful degradation if OPC not available
 
   // PostgreSQL full-text search handles stopwords automatically via plainto_tsquery
   // Just clean up the intent: remove paths, underscores, short words

--- a/.claude/hooks/src/shared/db-utils-pg.ts
+++ b/.claude/hooks/src/shared/db-utils-pg.ts
@@ -13,8 +13,8 @@
  */
 
 import { spawnSync } from 'child_process';
-import { join } from 'path';
 import type { QueryResult } from './types.js';
+import { requireOpcDir } from './opc-path.js';
 
 // Re-export SAFE_ID_PATTERN and isValidId from pattern-router for convenience
 export { SAFE_ID_PATTERN, isValidId } from './pattern-router.js';
@@ -44,8 +44,7 @@ export function getPgConnectionString(): string {
  * @returns QueryResult with success, stdout, and stderr
  */
 export function runPgQuery(pythonCode: string, args: string[] = []): QueryResult {
-  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-  const opcDir = join(projectDir, 'opc');
+  const opcDir = requireOpcDir();
 
   // Wrap the Python code to use asyncio.run() for async queries
   const wrappedCode = `

--- a/.claude/hooks/src/shared/learning-extractor.ts
+++ b/.claude/hooks/src/shared/learning-extractor.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { join } from 'path';
+import { getOpcDir } from './opc-path.js';
 
 export interface Learning {
   what: string;      // What happened
@@ -34,7 +34,8 @@ export async function storeLearning(
   sessionId: string,
   projectDir: string
 ): Promise<boolean> {
-  const opcDir = join(projectDir, 'opc');
+  const opcDir = getOpcDir();
+  if (!opcDir) return false;  // Graceful degradation
 
   // Build args based on outcome
   const args = [

--- a/.claude/hooks/src/shared/opc-path.ts
+++ b/.claude/hooks/src/shared/opc-path.ts
@@ -1,0 +1,70 @@
+/**
+ * Cross-platform OPC directory resolution for hooks.
+ *
+ * Supports running Claude Code in any directory by:
+ * 1. Checking CLAUDE_OPC_DIR environment variable (global setup)
+ * 2. Falling back to ${CLAUDE_PROJECT_DIR}/opc (local setup)
+ * 3. Gracefully degrading if neither exists
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Get the OPC directory path, or null if not available.
+ *
+ * Resolution order:
+ * 1. CLAUDE_OPC_DIR env var (for global hook installation)
+ * 2. ${CLAUDE_PROJECT_DIR}/opc (for running within CC project)
+ * 3. ${CWD}/opc (fallback)
+ *
+ * @returns Path to opc directory, or null if not found
+ */
+export function getOpcDir(): string | null {
+  // 1. Try env var (works when hooks are installed globally)
+  const envOpcDir = process.env.CLAUDE_OPC_DIR;
+  if (envOpcDir && existsSync(envOpcDir)) {
+    return envOpcDir;
+  }
+
+  // 2. Try project-relative path
+  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const localOpc = join(projectDir, 'opc');
+  if (existsSync(localOpc)) {
+    return localOpc;
+  }
+
+  // 3. Not available
+  return null;
+}
+
+/**
+ * Get OPC directory or exit gracefully if not available.
+ *
+ * Use this in hooks that require OPC infrastructure.
+ * If OPC is not available, outputs {"result": "continue"} and exits,
+ * allowing the hook to be a no-op in non-CC projects.
+ *
+ * @returns Path to opc directory (never null - exits if not found)
+ */
+export function requireOpcDir(): string {
+  const opcDir = getOpcDir();
+  if (!opcDir) {
+    // Graceful degradation - hook becomes no-op
+    console.log(JSON.stringify({ result: "continue" }));
+    process.exit(0);
+  }
+  return opcDir;
+}
+
+/**
+ * Check if OPC infrastructure is available.
+ *
+ * Use this for optional OPC features that should silently skip
+ * when running outside a Continuous-Claude environment.
+ *
+ * @returns true if OPC directory exists and is accessible
+ */
+export function hasOpcDir(): boolean {
+  return getOpcDir() !== null;
+}


### PR DESCRIPTION
- Add opc-path.ts helper with getOpcDir() and requireOpcDir()
- Update db-utils-pg.ts to use requireOpcDir()
- Update memory-awareness.ts to use getOpcDir() with graceful degradation
- Update learning-extractor.ts to use getOpcDir()

Hooks now work when:
1. CLAUDE_OPC_DIR env var is set (global install)
2. Running in CC project directory (local opc/)
3. Neither (graceful no-op)

Fixes: hooks fail silently when installed globally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-project OPC resolution and updates hooks for global compatibility and safe degradation.
> 
> - New `shared/opc-path.ts` with `getOpcDir()`, `requireOpcDir()`, and `hasOpcDir()` resolving via `CLAUDE_OPC_DIR` or `${CLAUDE_PROJECT_DIR}/opc`
> - `db-utils-pg.ts` now uses `requireOpcDir()` and sets `cwd`/`PYTHONPATH`/`OPC_POSTGRES_URL` for Python calls
> - `memory-awareness.ts` and `learning-extractor.ts` switch to `getOpcDir()` with graceful no-op when OPC is unavailable
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33d3bb6aea76ce8ee75a00fa9ce0318a8069c334. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized OPC directory resolution utility supporting environment variables and automatic fallback detection.

* **Bug Fixes**
  * Enhanced graceful degradation handling when OPC configurations are unavailable.

* **Refactor**
  * Unified directory path resolution across multiple components for consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->