### PR TITLE
fix: setup wizard Docker daemon retry and compose file paths

### DIFF
--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -170,6 +170,23 @@ async def check_prerequisites_with_install_offers() -> dict[str, Any]:
         console.print("  [yellow]Docker is installed but the daemon is not running.[/yellow]")
         console.print("  Please start Docker Desktop or the Docker service.")
 
+        # Retry loop for daemon startup
+        max_retries = 3
+        for attempt in range(max_retries):
+            if Confirm.ask(f"\n  Retry checking Docker daemon? (attempt {attempt + 1}/{max_retries})", default=True):
+                console.print("  Checking Docker daemon...")
+                await asyncio.sleep(2)  # Give daemon time to start
+                docker_info = await check_docker_installed()
+                if docker_info.get("daemon_running", False):
+                    result["docker"] = True
+                    result["docker_daemon_running"] = True
+                    console.print("  [green]OK[/green] Docker daemon is now running!")
+                    break
+                else:
+                    console.print("  [yellow]Docker daemon still not running.[/yellow]")
+            else:
+                break
+
     # Check elan/Lean4 (optional, for theorem proving with /prove skill)
     if not result["elan"]:
         console.print("\n  [dim]Optional: Lean4/elan not found (needed for /prove skill)[/dim]")


### PR DESCRIPTION
- Add retry loop when Docker daemon not running (up to 3 attempts)
- Add -f compose file flag to wait_for_services and run_migrations
- Fix database name from claude_continuity to continuous_claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced setup wizard with automatic Docker daemon detection retry mechanism. If Docker is installed but the daemon isn't running, the wizard will attempt to verify daemon status up to 3 times with 2-second pauses between attempts. If the daemon becomes available, setup continues normally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->