### PR TITLE
fix: wrap hook commands in bash -c for paths with spaces

### DIFF
--- a/.claude/hooks/package-lock.json
+++ b/.claude/hooks/package-lock.json
@@ -812,7 +812,6 @@
             "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -1348,7 +1347,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1735,7 +1733,6 @@
             "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "python3 $CLAUDE_PROJECT_DIR/.claude/scripts/status.py"
+    "command": "bash -c 'python3 \"$CLAUDE_PROJECT_DIR/.claude/scripts/status.py\"'"
   },
   "hooks": {
     "PreToolUse": [
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/pre-tool-use-broadcast.mjs"
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/pre-tool-use-broadcast.mjs\"'"
           }
         ]
       },
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/path-rules.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/path-rules.mjs\"'",
             "timeout": 5
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/tldr-read-enforcer.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/tldr-read-enforcer.mjs\"'",
             "timeout": 20
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/smart-search-router.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/smart-search-router.mjs\"'",
             "timeout": 10
           }
         ]
@@ -48,12 +48,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/tldr-context-inject.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/tldr-context-inject.mjs\"'",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/arch-context-inject.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/arch-context-inject.mjs\"'",
             "timeout": 30
           }
         ]
@@ -63,17 +63,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/file-claims.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/file-claims.mjs\"'",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/edit-context-inject.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/edit-context-inject.mjs\"'",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/signature-helper.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/signature-helper.mjs\"'",
             "timeout": 5
           }
         ]
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $HOME/.claude/hooks/dist/pre-compact-continuity.mjs"
+            "command": "node \"$HOME/.claude/hooks/dist/pre-compact-continuity.mjs\""
           }
         ]
       }
@@ -94,16 +94,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash $HOME/.claude/plugins/braintrust-tracing/hooks/session_start.sh"
+            "command": "bash \"$HOME/.claude/plugins/braintrust-tracing/hooks/session_start.sh\""
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/session-register.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/session-register.mjs\"'",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/session-symbol-index.py",
+            "command": "bash -c 'python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-symbol-index.py\"'",
             "timeout": 5
           }
         ]
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $HOME/.claude/hooks/dist/session-start-continuity.mjs"
+            "command": "node \"$HOME/.claude/hooks/dist/session-start-continuity.mjs\""
           }
         ]
       },
@@ -122,12 +122,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/session-start-tldr-cache.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/session-start-tldr-cache.mjs\"'",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/session-start-dead-code.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/session-start-dead-code.mjs\"'",
             "timeout": 30
           }
         ]
@@ -138,26 +138,26 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $HOME/.claude/hooks/dist/skill-activation-prompt.mjs"
+            "command": "node \"$HOME/.claude/hooks/dist/skill-activation-prompt.mjs\""
           },
           {
             "type": "command",
-            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/premortem-suggest.py",
+            "command": "bash -c 'python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/premortem-suggest.py\"'",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/memory-awareness.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/memory-awareness.mjs\"'",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/impact-refactor.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/impact-refactor.mjs\"'",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash $HOME/.claude/plugins/braintrust-tracing/hooks/user_prompt_submit.sh"
+            "command": "bash \"$HOME/.claude/plugins/braintrust-tracing/hooks/user_prompt_submit.sh\""
           }
         ]
       }
@@ -168,22 +168,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $HOME/.claude/hooks/dist/typescript-preflight.mjs",
+            "command": "node \"$HOME/.claude/hooks/dist/typescript-preflight.mjs\"",
             "timeout": 40
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/compiler-in-the-loop.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/compiler-in-the-loop.mjs\"'",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/post-edit-notify.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/post-edit-notify.mjs\"'",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/post-edit-diagnostics.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/post-edit-diagnostics.mjs\"'",
             "timeout": 10
           }
         ]
@@ -193,7 +193,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $HOME/.claude/hooks/dist/handoff-index.mjs"
+            "command": "node \"$HOME/.claude/hooks/dist/handoff-index.mjs\""
           }
         ]
       },
@@ -202,7 +202,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.claude/hooks/post-tool-use-tracker.py",
+            "command": "python3 \"$HOME/.claude/hooks/post-tool-use-tracker.py\"",
             "timeout": 120
           }
         ]
@@ -212,7 +212,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash $HOME/.claude/plugins/braintrust-tracing/hooks/post_tool_use.sh"
+            "command": "bash \"$HOME/.claude/plugins/braintrust-tracing/hooks/post_tool_use.sh\""
           }
         ]
       },
@@ -221,7 +221,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/import-validator.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/import-validator.mjs\"'",
             "timeout": 5
           }
         ]
@@ -231,7 +231,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/import-error-detector.mjs",
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/import-error-detector.mjs\"'",
             "timeout": 5
           }
         ]
@@ -242,15 +242,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/auto-handoff-stop.py"
+            "command": "bash -c 'python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/auto-handoff-stop.py\"'"
           },
           {
             "type": "command",
-            "command": "bash $CLAUDE_PROJECT_DIR/.claude/plugins/braintrust-tracing/hooks/stop_hook.sh"
+            "command": "bash -c 'bash \"$CLAUDE_PROJECT_DIR/.claude/plugins/braintrust-tracing/hooks/stop_hook.sh\"'"
           },
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/dist/compiler-in-the-loop-stop.mjs"
+            "command": "bash -c 'node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dist/compiler-in-the-loop-stop.mjs\"'"
           }
         ]
       }
@@ -260,15 +260,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node $HOME/.claude/hooks/dist/session-end-cleanup.mjs"
+            "command": "node \"$HOME/.claude/hooks/dist/session-end-cleanup.mjs\""
           },
           {
             "type": "command",
-            "command": "node $HOME/.claude/hooks/dist/session-outcome.mjs"
+            "command": "node \"$HOME/.claude/hooks/dist/session-outcome.mjs\""
           },
           {
             "type": "command",
-            "command": "bash $HOME/.claude/plugins/braintrust-tracing/hooks/session_end.sh"
+            "command": "bash \"$HOME/.claude/plugins/braintrust-tracing/hooks/session_end.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Wraps all 25 `CLAUDE_PROJECT_DIR` hooks in `bash -c '...'` to properly handle paths with spaces
- Fixes hooks failing when project directory contains spaces (e.g., "Groove Jones Dropbox")

## Problem
Hooks using `$CLAUDE_PROJECT_DIR` would fail with errors like:
```
/bin/sh: Jones: command not found
```

## Solution
Changed pattern from:
```json
"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/script.sh"
```
To:
```json
"command": "bash -c '$CLAUDE_PROJECT_DIR/.claude/hooks/script.sh'"
```

Single quotes outside pass `$CLAUDE_PROJECT_DIR` literally to bash, which then expands it properly with spaces preserved.

## Test plan
- [x] Verified JSON is valid: `python3 -c "import json; json.load(open('.claude/settings.json'))"`
- [x] Verified all hooks wrapped: `grep 'CLAUDE_PROJECT_DIR' .claude/settings.json | grep -v 'bash -c' | wc -l` returns 0
- [x] Tested hooks execute successfully in path with spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized command execution framework by implementing improved wrapper handling with standardized argument passing methodology to enhance reliability and consistency
  * Reorganized configuration structure through matcher-based grouping to enable better command categorization and management across different execution contexts
  * Applied consistent formatting standards including comprehensive path quoting conventions and timeout value preservation throughout configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->