### PR TITLE
(refactor): Adding Frontmatter to agents and updating contribution guidelines

### DIFF
--- a/.claude/agents/context-query-agent.md
+++ b/.claude/agents/context-query-agent.md
@@ -1,5 +1,7 @@
 ---
 name: context-query-agent
+description: Query the artifact index for precedent and guidance
+model: sonnet
 ---
 
 # Context Query Agent

--- a/.claude/agents/research-codebase.md
+++ b/.claude/agents/research-codebase.md
@@ -1,5 +1,7 @@
 ---
 name: research-codebase
+description: Document the codebase comprehensively
+model: sonnet
 ---
 
 # Research Codebase Agent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,15 +18,14 @@ Thank you for your interest in contributing! This guide covers how to add skills
 ## Development Setup
 
 ```bash
-# Clone the repository
-git clone https://github.com/parcadei/continuous-claude.git
-cd continuous-claude
+# Clone (your fork) of the repository
+cd Continuous-Claude-v3/opc
 
 # Install Python dependencies
 uv sync
 
 # Install hook dependencies (TypeScript)
-cd .claude/hooks && npm install && npm run build && cd ../..
+cd ../.claude/hooks && npm install && npm run build && cd ../../opc
 
 # Verify installation
 claude
@@ -108,22 +107,13 @@ Agents are specialized AI workers defined in `.claude/agents/<agent-name>.md`.
 ### Agent Structure
 
 ```markdown
-# agent-name
-
-## Purpose
-
-One-line description of what this agent does.
-
-## Model
-
-Preferred model: opus | sonnet | haiku
-
-## Tools
-
-- Read
-- Grep
-- Glob
-- [other tools this agent needs]
+# Frontmatter
+---
+name: <name of agent>
+description: <one line description of agent>
+model: <preferred model: opus | sonnet | haiku>
+tools: <list tools agent needs (optional): Read | Grep | Glob | etc...>
+---
 
 ## Prompt
 


### PR DESCRIPTION
## 🤔 Problem

Claude version: 2.1.4
OS: MacOS 15.7.3

Error post-installation:

```
Agent Parse Errors
 └ Failed to parse 2 agent file(s):
   └ /Users/.../.claude/agents/context-query-agent.md: Missing required "description" field in frontmatter
   └ /Users/.../.claude/agents/research-codebase.md: Missing required "description" field in frontmatter
```
Also, `CONTRIBUTING.md` asks users to `uv sync` from wrong folder



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions for improved onboarding workflow.
  * Revised agent structure documentation with updated configuration format and examples.
  * Enhanced agent metadata configuration with description and model fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->