### PR TITLE
Fix formatting of description in SKILL.md

### DIFF
--- a/.claude/skills/completion-check/SKILL.md
+++ b/.claude/skills/completion-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: completion-check
-description: Completion Check: Verify Infrastructure Is Wired
+description: "Completion Check: Verify Infrastructure Is Wired"
 user-invocable: false
 ---
 


### PR DESCRIPTION
it causes Failed to parse YAML frontmatter: incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line this fix should fix that, before it might work with cc but with opencode or other agents gives an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation metadata formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->