### PR TITLE
Syntax Warning Causing Json Output Breakage

### DIFF
--- a/.claude/servers/repoprompt/file_search.py
+++ b/.claude/servers/repoprompt/file_search.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
+
 from pydantic import BaseModel, Field
-from typing import Literal
+
 
 class FileSearchParams(BaseModel):
     """Parameters for file_search"""
+
     context_lines: Optional[int] = None
     """Lines of context before/after matches (alias: -C)"""
     count_only: Optional[bool] = None
@@ -21,59 +23,62 @@ class FileSearchParams(BaseModel):
     whole_word: Optional[bool] = None
     """Match whole words only"""
 
+
 async def file_search(params: FileSearchParams) -> Dict[str, Any]:
-    """
-    Search by file path and/or file content.
+    r"""
+        Search by file path and/or file content.
 
-Defaults
-- regex=true (regular expressions by default)
-- case-insensitive
-- spaces match flexible whitespace
-- results use 1‑based line numbers
-- max_results default: 50 (request higher if needed)
+    Defaults
+    - regex=true (regular expressions by default)
+    - case-insensitive
+    - spaces match flexible whitespace
+    - results use 1‑based line numbers
+    - max_results default: 50 (request higher if needed)
 
-Response capping
-- The returned payload is capped to ~50k characters.
-- When the cap is hit, we exclude whole results (never cut a line) and report how many were omitted under 'omitted_*' in the response.
+    Response capping
+    - The returned payload is capped to ~50k characters.
+    - When the cap is hit, we exclude whole results (never cut a line) and report how many were omitted under 'omitted_*' in the response.
 
-Params
-- pattern (required)
-- regex: true|false
-- mode: "auto" | "path" | "content" | "both" (default "auto")
-- filter: { extensions, exclude, paths }
-- max_results, count_only, context_lines, whole_word
+    Params
+    - pattern (required)
+    - regex: true|false
+    - mode: "auto" | "path" | "content" | "both" (default "auto")
+    - filter: { extensions, exclude, paths }
+    - max_results, count_only, context_lines, whole_word
 
-Parameter aliases (for compatibility)
-- `-C`: alias for context_lines (e.g., `-C: 5` same as `context_lines: 5`)
-- `path`: shorthand for single-file search (e.g., `path: "file.swift"` same as `filter: {paths: ["file.swift"]}`)
+    Parameter aliases (for compatibility)
+    - `-C`: alias for context_lines (e.g., `-C: 5` same as `context_lines: 5`)
+    - `path`: shorthand for single-file search (e.g., `path: "file.swift"` same as `filter: {paths: ["file.swift"]}`)
 
-Literal mode (`regex=false`)
-- Special characters are matched literally; no escaping needed
+    Literal mode (`regex=false`)
+    - Special characters are matched literally; no escaping needed
 
-Regex mode (`regex=true`)
-- Full regular expressions (groups, lookarounds, anchors `^`/`$`); `whole_word` adds word boundaries
+    Regex mode (`regex=true`)
+    - Full regular expressions (groups, lookarounds, anchors `^`/`$`); `whole_word` adds word boundaries
 
-Path search
-- regex=false: `*` and `?` wildcards (match across folders)
-- regex=true: full regex on relative paths
+    Path search
+    - regex=false: `*` and `?` wildcards (match across folders)
+    - regex=true: full regex on relative paths
 
-Examples
-- Literal: {"pattern":"frame(minWidth:", "regex":false}
-- Regex:   {"pattern":"frame\(minWidth:", "regex":true}
-- OR:      {"pattern":"performSearch|searchUsers", "regex":true}
-- Path:    {"pattern":"*.swift", "mode":"path"}
+    Examples
+    - Literal: {"pattern":"frame(minWidth:", "regex":false}
+    - Regex:   {"pattern":"frame\(minWidth:", "regex":true}
+    - OR:      {"pattern":"performSearch|searchUsers", "regex":true}
+    - Path:    {"pattern":"*.swift", "mode":"path"}
 
-    Args:
-        params: Tool parameters
+        Args:
+            params: Tool parameters
 
-    Returns:
-        Tool execution result
+        Returns:
+            Tool execution result
     """
     from runtime.mcp_client import call_mcp_tool
     from runtime.normalize_fields import normalize_field_names
 
     # Call tool
-    result = await call_mcp_tool("repoprompt__file_search", params.model_dump(exclude_none=True))
+    result = await call_mcp_tool(
+        "repoprompt__file_search", params.model_dump(exclude_none=True)
+    )
 
     # Defensive unwrapping
     unwrapped = getattr(result, "value", result)


### PR DESCRIPTION
## Problem 🤔 
The file_search.py MCP server contains an invalid escape sequence that causes Python to emit a SyntaxWarning. When tldr analyzes the codebase, this warning gets appended to the JSON output, breaking JSON parsing.

### Failure

Running tldr structure . --lang python produces corrupted output:

```
{
  "root": ".",
  "files": [...]
}

servers/repoprompt/file_search.py:62: SyntaxWarning: "\(" is an invalid escape sequence
```

This causes JSON parsers to fail:
`json.JSONDecodeError: Extra data: line 5 column 1 (char 33)`

Line 62 of the docstring contains \( in a regular string:

```python
  async def file_search(params: FileSearchParams) -> Dict[str, Any]:
      """
      ...
      - Regex:   {"pattern":"frame\(minWidth:", "regex":true}
```

When Python's AST parser analyzes this file, it emits a warning to stderr that pollutes the tldr JSON output stream.

### Fix

Change line 25 to use a raw string:
  
```python
async def file_search(params: FileSearchParams) -> Dict[str, Any]:
  -    """
  +    r"""
       Search by file path and/or file content.
```

Verification:

After fix, tldr produces clean JSON with no warnings:
tldr structure . --lang python 2>/dev/null | python3 -m json.tool