### PR TITLE
fix: Correct perplexity_search.py path in skills

### DIFF
--- a/.claude/skills/perplexity-search/SKILL.md
+++ b/.claude/skills/perplexity-search/SKILL.md
@@ -28,13 +28,13 @@ Web search with AI-powered answers, deep research, and chain-of-thought reasonin
 
 ### Quick question (AI answer)
 ```bash
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --ask "What is the latest version of Python?"
 ```
 
 ### Direct web search (ranked results, no AI)
 ```bash
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --search "SQLite graph database patterns" \
     --max-results 5 \
     --recency week
@@ -42,19 +42,19 @@ uv run python scripts/perplexity_search.py \
 
 ### AI-synthesized research
 ```bash
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --research "compare FastAPI vs Django for microservices"
 ```
 
 ### Chain-of-thought reasoning
 ```bash
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --reason "should I use Neo4j or SQLite for small graph under 10k nodes?"
 ```
 
 ### Deep comprehensive research
 ```bash
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --deep "state of AI agent observability 2025"
 ```
 
@@ -89,20 +89,20 @@ uv run python scripts/perplexity_search.py \
 
 ```bash
 # Find recent sources on a topic
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --search "OpenTelemetry AI agent tracing" \
     --recency month --max-results 5
 
 # Get AI synthesis
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --research "best practices for AI agent logging 2025"
 
 # Make a decision
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --reason "microservices vs monolith for startup MVP"
 
 # Deep dive
-uv run python scripts/perplexity_search.py \
+uv run python scripts/mcp/perplexity_search.py \
     --deep "comprehensive guide to building feedback loops for autonomous agents"
 ```
 

--- a/.claude/skills/research-external/SKILL.md
+++ b/.claude/skills/research-external/SKILL.md
@@ -192,26 +192,26 @@ Primary tool: **perplexity-search** - Find recommended approaches, patterns, ant
 
 ```bash
 # AI-synthesized research (sonar-pro)
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/perplexity_search.py \
+(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
   --research "$TOPIC best practices 2024 2025")
 
 # If comparing alternatives
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/perplexity_search.py \
+(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
   --reason "$TOPIC vs alternatives - which to choose?")
 ```
 
 **Thorough depth additions:**
 ```bash
 # Chain-of-thought for complex decisions
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/perplexity_search.py \
+(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
   --reason "$TOPIC tradeoffs and considerations 2025")
 
 # Deep comprehensive research
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/perplexity_search.py \
+(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
   --deep "$TOPIC comprehensive guide 2025")
 
 # Recent developments
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/perplexity_search.py \
+(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
   --search "$TOPIC latest developments" \
   --recency month --max-results 5)
 ```
@@ -228,7 +228,7 @@ Use ALL available MCP tools - comprehensive multi-source research.
 
 **Step 2b: Web research (perplexity)**
 ```bash
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/perplexity_search.py \
+(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
   --research "$TOPIC")
 ```
 


### PR DESCRIPTION
The perplexity-search and research-external skills referenced `scripts/perplexity_search.py` but the actual script location is `scripts/mcp/perplexity_search.py`.

This caused "file not found" errors when using the skills.

Files fixed:
- .claude/skills/perplexity-search/SKILL.md
- .claude/skills/research-external/SKILL.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill documentation for search and research capabilities to reflect current script references, ensuring users access the correct resources when following implementation examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->