### PR TITLE
fix: add missing frontmatter to skills and fix model reference

### DIFF
--- a/.claude/skills/loogle-search/SKILL.md
+++ b/.claude/skills/loogle-search/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: loogle-search
+description: Search Mathlib for lemmas by type signature pattern
+allowed-tools: [Bash, Read]
+---
+
 # Loogle Search - Mathlib Type Signature Search
 
 Search Mathlib for lemmas by type signature pattern.

--- a/.claude/skills/math-unified/SKILL.md
+++ b/.claude/skills/math-unified/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: math
+name: math-unified
 description: Unified math capabilities - computation, solving, and explanation. I route to the right tool.
 triggers: ["calculate", "compute", "solve", "integrate", "derivative", "eigenvalue", "matrix", "simplify", "factor", "limit", "series", "differential equation", "unit convert", "explain", "what is", "how does"]
 allowed-tools: [Bash, Read, Write]

--- a/.claude/skills/mot/SKILL.md
+++ b/.claude/skills/mot/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mot
 description: System health check (MOT) for skills, agents, hooks, and memory
-model: sonnet
 allowed-tools: [Read, Bash, Glob, Grep]
 ---
 

--- a/.claude/skills/recall/SKILL.md
+++ b/.claude/skills/recall/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: recall
+description: Query semantic memory for relevant learnings from past sessions
+allowed-tools: [Bash, Read]
+---
+
 # Recall - Semantic Memory Retrieval
 
 Query the memory system for relevant learnings from past sessions.

--- a/.claude/skills/remember/SKILL.md
+++ b/.claude/skills/remember/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: remember
+description: Store a learning, pattern, or decision in the memory system for future recall
+allowed-tools: [Bash, Read]
+---
+
 # Remember - Store Learning in Memory
 
 Store a learning, pattern, or decision in the memory system for future recall.

--- a/.claude/skills/system_overview/SKILL.md
+++ b/.claude/skills/system_overview/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: system_overview
+description: Show users how Continuous Claude works - hooks, memory, and coordination
+allowed-tools: [Bash, Read]
+---
+
 # System Overview
 
 Show users how Continuous Claude works - the opinionated setup with hooks, memory, and coordination.

--- a/.claude/skills/tldr-deep/SKILL.md
+++ b/.claude/skills/tldr-deep/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: tldr-deep
+description: Full 5-layer analysis of a specific function for debugging or deep understanding
+allowed-tools: [Bash, Read]
+---
+
 # TLDR Deep Analysis
 
 Full 5-layer analysis of a specific function. Use when debugging or deeply understanding code.

--- a/.claude/skills/tldr-overview/SKILL.md
+++ b/.claude/skills/tldr-overview/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: tldr-overview
+description: Get a token-efficient overview of any project using the TLDR stack
+allowed-tools: [Bash, Read]
+---
+
 # TLDR Project Overview
 
 Get a token-efficient overview of any project using the TLDR stack.

--- a/.claude/skills/tldr-router/SKILL.md
+++ b/.claude/skills/tldr-router/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: tldr-router
+description: Maps questions to the optimal tldr command for code analysis
+allowed-tools: [Bash, Read]
+---
+
 # TLDR Smart Router
 
 Maps questions to the optimal tldr command. Use this to pick the right layer.

--- a/.claude/skills/tour/SKILL.md
+++ b/.claude/skills/tour/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: tour
+description: Friendly onboarding when users ask about capabilities
+allowed-tools: [Read]
+---
+
 # Tour: What Can I Do?
 
 Friendly onboarding when users ask about capabilities.


### PR DESCRIPTION
## Summary

- Remove invalid `model: sonnet` from `mot/SKILL.md` (causes API 404 error - the API doesn't recognize shorthand model names)
- Add YAML frontmatter to 8 skills that were missing it: `recall`, `tldr-router`, `tldr-overview`, `tour`, `system_overview`, `tldr-deep`, `remember`, `loogle-search`
- Fix name mismatch in `math-unified/SKILL.md` (was `name: math`, should match directory name)

## Test plan

- [x] Verified `/mot` skill now works without API errors
- [x] Ran MOT audit - all 156 skills now pass frontmatter validation
- [x] Verified name consistency check passes (156/156)

🤖 Generated with [Claude Code](https://claude.ai/code)