### PR TITLE
fix: use CLAUDE_CONFIG_DIR for tldr_stats.py

### DIFF
--- a/.claude/scripts/tldr_stats.py
+++ b/.claude/scripts/tldr_stats.py
@@ -153,7 +153,8 @@ def get_claude_stats(session_id: str) -> dict:
 def get_model_breakdown(session_id: str) -> dict:
     """Get per-model token breakdown from session JSONL."""
     model_breakdown = {}
-    projects_base = Path.home() / '.opc-dev' / 'projects'
+    config_dir = Path(os.environ.get('CLAUDE_CONFIG_DIR', str(Path.home() / '.claude')))
+    projects_base = config_dir / 'projects'
 
     if not projects_base.exists():
         return {}


### PR DESCRIPTION
## Summary

- `tldr_stats.py` was hardcoded to `~/.opc-dev/projects` which only works for users with that specific `CLAUDE_CONFIG_DIR` setting
- Now respects `CLAUDE_CONFIG_DIR` env var with `~/.claude` as default

## Problem

Anyone using the default Claude Code config (`~/.claude`) would get empty stats because the script looked in the wrong directory.

## Fix

```python
# Before
projects_base = Path.home() / '.opc-dev' / 'projects'

# After  
config_dir = Path(os.environ.get('CLAUDE_CONFIG_DIR', str(Path.home() / '.claude')))
projects_base = config_dir / 'projects'
```

## Test

Works for both:
- Default users: `~/.claude/projects/`
- Custom config: `CLAUDE_CONFIG_DIR=~/.opc-dev` → `~/.opc-dev/projects/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `tldr_stats.py` finds session JSONL files across different Claude Code config locations.
> 
> - `get_model_breakdown` now derives `projects_base` from `CLAUDE_CONFIG_DIR` (default `~/.claude`) rather than hardcoding `~/.opc-dev/projects`
> - Improves compatibility for users with default or custom config directories
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f5ea7d0fe421c050e0b31cd0e6fd0d17f1e2da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified configuration directory resolution logic. The system now reads an optional environment variable to determine a custom configuration directory, falling back to a default location if the variable is not set. This provides greater flexibility in managing configuration files while maintaining backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixes hardcoded config path to respect `CLAUDE_CONFIG_DIR` environment variable. Previously, `tldr_stats.py` only worked for users with config in `~/.opc-dev`, breaking the default Claude Code setup.

**Changes:**
- Replaced hardcoded `Path.home() / '.opc-dev' / 'projects'` with environment-aware path resolution
- Uses `CLAUDE_CONFIG_DIR` env var when set, falls back to `~/.claude` (Claude Code default)
- Pattern matches `CLAUDE_SESSION_ID` usage elsewhere in `.claude/scripts/status.py` and `status.sh`

**Missing:**
- No tests included despite repository requirement: "Please ensure all PRs have tests to prove fixes"

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor concern about missing tests
- The code change is correct and follows established patterns from other scripts in the codebase. The logic is straightforward - read env var with fallback to default. However, the repository explicitly requires tests for all fixes, and none are included. The fix itself is low-risk since it only affects path resolution and gracefully handles missing directories.
- No files require special attention - the change is isolated and simple

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .claude/scripts/tldr_stats.py | Fixed hardcoded `~/.opc-dev/projects` path to respect `CLAUDE_CONFIG_DIR` environment variable with `~/.claude` as default fallback |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Script as tldr_stats.py
    participant Env as Environment
    participant FS as File System

    User->>Script: Execute tldr_stats.py
    Script->>Env: Read CLAUDE_CONFIG_DIR
    alt CLAUDE_CONFIG_DIR set
        Env-->>Script: Custom path (e.g., ~/.opc-dev)
    else CLAUDE_CONFIG_DIR not set
        Env-->>Script: Default ~/.claude
    end
    Script->>Script: config_dir = Path(value)
    Script->>Script: projects_base = config_dir / 'projects'
    Script->>FS: Check if projects_base.exists()
    alt projects_base exists
        FS-->>Script: True
        Script->>FS: Search for session JSONL files
        FS-->>Script: Return session data
        Script->>User: Display token statistics
    else projects_base not exists
        FS-->>Script: False
        Script->>User: Display empty/no stats
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->