### PR TITLE
fix: install scripts/mcp/ for external research tools

### DIFF
--- a/.claude/scripts/mcp
+++ b/.claude/scripts/mcp
@@ -1,0 +1,1 @@
+../../opc/scripts/mcp

--- a/opc/scripts/setup/claude_integration.py
+++ b/opc/scripts/setup/claude_integration.py
@@ -516,6 +516,17 @@ def install_opc_integration(
             shutil.copytree(opc_scripts_tldr, target_scripts_tldr)
             result["installed_scripts"] += len(list(target_scripts_tldr.rglob("*.py")))
 
+        # Copy scripts/mcp/ for external research/API tools
+        # This enables perplexity_search, firecrawl_scrape, github_search, nia_docs, morph_* scripts
+        # Used by skills like /perplexity-search, /research-external, /firecrawl-scrape
+        opc_scripts_mcp = opc_source.parent / "opc" / "scripts" / "mcp"
+        target_scripts_mcp = target_dir / "scripts" / "mcp"
+        if opc_scripts_mcp.exists():
+            if target_scripts_mcp.exists():
+                shutil.rmtree(target_scripts_mcp)
+            shutil.copytree(opc_scripts_mcp, target_scripts_mcp)
+            result["installed_scripts"] += len(list(target_scripts_mcp.rglob("*.py")))
+
         # Copy individual root scripts used by skills/hooks
         # These are referenced by skills like /qlty-check, /ast-grep-find, /mcp-chaining
         root_scripts = [

--- a/opc/scripts/setup/update.py
+++ b/opc/scripts/setup/update.py
@@ -246,6 +246,7 @@ def run_update() -> None:
         ("agents", claude_dir / "agents", {".md", ".yaml", ".yml"}),
         ("scripts", claude_dir / "scripts", {".py", ".sh"}),
         ("scripts/core", claude_dir / "scripts" / "core", {".py"}),
+        ("scripts/mcp", claude_dir / "scripts" / "mcp", {".py"}),
     ]
 
     all_new = []


### PR DESCRIPTION
The setup wizard (claude_integration.py) and update wizard (update.py) install scripts from opc/scripts/ to ~/.claude/scripts/, but mcp/ was missing. This directory contains essential external API tools used by skills like /perplexity-search, /research-external, /firecrawl-scrape.

Scripts in mcp/:
- perplexity_search.py - AI web search/research
- firecrawl_scrape.py - Web scraping
- github_search.py - GitHub search
- nia_docs.py - Documentation search
- morph_apply.py, morph_search.py - Code search/apply

This was an oversight from commit f36ce28 which added other script directories (core/, cc_math/, tldr/) but missed mcp/.

## Changes

1. Add .claude/scripts/mcp as symlink to ../../opc/scripts/mcp (avoids duplication since mcp/ scripts are standalone)

2. Update claude_integration.py to copy opc/scripts/mcp/ during install

3. Update update.py to include scripts/mcp in the checks list

## Before (fails from any project except CC)
```
$ cd ~/my-project && claude
> /perplexity-search --search "test"
Error: scripts/mcp/perplexity_search.py not found
```

## After (works from anywhere)
```
$ cd ~/my-project && claude
> /perplexity-search --search "test"
✓ Works - uses ~/.claude/scripts/mcp/perplexity_search.py
```

## Architecture note

Unlike core/ scripts which have separate opc/ (development) and .claude/ (distribution) versions, mcp/ scripts are standalone with no opc-specific dependencies. Using a symlink avoids maintaining duplicate files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled new research and API tooling capabilities including search, web scraping, documentation access, and data transformation features.

* **Chores**
  * Updated system installation and update processes to manage new script integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->