### PR TITLE
fix: correct GitHub API parameter name in search script

### DIFF
--- a/opc/scripts/mcp/github_search.py
+++ b/opc/scripts/mcp/github_search.py
@@ -38,7 +38,7 @@ async def main():
     }
 
     tool_name = tool_map[args.type]
-    params = {"query": args.query, "perPage": args.limit}
+    params = {"q": args.query, "perPage": args.limit}
 
     if args.owner:
         params["owner"] = args.owner


### PR DESCRIPTION
## Summary

- Fix parameter name in `github_search.py`: `query` → `q`
- GitHub Search API expects `q` parameter, not `query`

## Problem

The script was passing `{"query": ...}` but GitHub MCP server (which wraps GitHub Search API) expects `{"q": ...}`.

Error before fix:
```
Invalid input: [{"path":["q"],"message":"Required"}]
```

## Test

```bash
cd opc && uv run python -m runtime.harness scripts/mcp/github_search.py --type code --query "test"
```

Works after fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub search parameter handling to correctly pass search terms to the search function.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->