### PR TITLE
fix: Skills use wrong Python venv - add CLAUDE_OPC_DIR setup

### DIFF
--- a/.claude/rules/agent-memory-recall.md
+++ b/.claude/rules/agent-memory-recall.md
@@ -7,7 +7,7 @@ Before starting implementation tasks, agents should check for relevant learnings
 Agents (kraken, architect, phoenix, spark) should consider running:
 
 ```bash
-cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "<task keywords>" --k 3 --text-only
+cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "<task keywords>" --k 3 --text-only
 ```
 
 This is especially useful when:

--- a/.claude/rules/dynamic-recall.md
+++ b/.claude/rules/dynamic-recall.md
@@ -13,7 +13,7 @@ Query memory proactively when:
 ## How to Recall
 
 ```bash
-(cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "your search terms")
+(cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "your search terms")
 ```
 
 **IMPORTANT:** Always run from `opc/` directory to load correct environment variables.
@@ -22,16 +22,16 @@ Query memory proactively when:
 
 ```bash
 # Default: Hybrid RRF search (text + vector combined) - RECOMMENDED
-(cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "authentication patterns")
+(cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "authentication patterns")
 
 # More results
-(cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "error handling" --k 10)
+(cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "error handling" --k 10)
 
 # Pure vector search (higher similarity scores, 0.4-0.6 range)
-(cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "database schema" --vector-only
+(cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "database schema" --vector-only
 
 # Text-only search (fast, no embeddings)
-(cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "YAML format" --text-only
+(cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "YAML format" --text-only
 ```
 
 ## Backend Architecture
@@ -78,7 +78,7 @@ Use recall to avoid repeating mistakes and leverage past successes.
 When you discover something worth remembering, store it:
 
 ```bash
-cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/store_learning.py \
+cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/store_learning.py \
   --session-id "<short-identifier>" \
   --type <TYPE> \
   --content "<what you learned>" \
@@ -104,7 +104,7 @@ cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/store_lear
 ### Example
 
 ```bash
-cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/store_learning.py \
+cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/store_learning.py \
   --session-id "hook-debugging" \
   --type WORKING_SOLUTION \
   --content "TypeScript hooks require npm install in .claude/hooks/ before they work. The build.sh script compiles TS to JS in dist/." \

--- a/.claude/rules/proactive-delegation.md
+++ b/.claude/rules/proactive-delegation.md
@@ -73,7 +73,7 @@ Before research tasks, check for prior work:
 
 ```bash
 # Quick memory check
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/core/recall_learnings.py --query "<topic>" --k 3 --text-only)
+(cd $CLAUDE_OPC_DIR && uv run python scripts/core/recall_learnings.py --query "<topic>" --k 3 --text-only)
 ```
 
 If relevant memory found: "I researched this on [date] - reuse or refresh?"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -94,7 +94,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/persist-project-dir.sh"
+            "command": "bash $HOME/.claude/hooks/persist-project-dir.sh"
           },
           {
             "type": "command",

--- a/.claude/skills/recall/SKILL.md
+++ b/.claude/skills/recall/SKILL.md
@@ -27,7 +27,7 @@ Query the memory system for relevant learnings from past sessions.
 When this skill is invoked, run:
 
 ```bash
-cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "<ARGS>" --k 5
+cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/recall_learnings.py --query "<ARGS>" --k 5
 ```
 
 Where `<ARGS>` is the query provided by the user.

--- a/.claude/skills/remember/SKILL.md
+++ b/.claude/skills/remember/SKILL.md
@@ -44,7 +44,7 @@ Or with explicit type:
 When this skill is invoked, run:
 
 ```bash
-cd $CLAUDE_PROJECT_DIR/opc && PYTHONPATH=. uv run python scripts/core/store_learning.py \
+cd $CLAUDE_OPC_DIR && PYTHONPATH=. uv run python scripts/core/store_learning.py \
   --session-id "manual-$(date +%Y%m%d-%H%M)" \
   --type <TYPE or WORKING_SOLUTION> \
   --content "<ARGS>" \

--- a/.claude/skills/research-external/SKILL.md
+++ b/.claude/skills/research-external/SKILL.md
@@ -164,19 +164,19 @@ Primary tool: **nia-docs** - Find API documentation, usage patterns, code exampl
 
 ```bash
 # Semantic search in package
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python -m runtime.harness scripts/mcp/nia_docs.py \
+(cd $CLAUDE_OPC_DIR && uv run python -m runtime.harness scripts/mcp/nia_docs.py \
   --package "$LIBRARY" \
   --registry "$REGISTRY" \
   --query "$TOPIC" \
   --limit 10)
 
 # If thorough depth, also grep for specific patterns
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python -m runtime.harness scripts/mcp/nia_docs.py \
+(cd $CLAUDE_OPC_DIR && uv run python -m runtime.harness scripts/mcp/nia_docs.py \
   --package "$LIBRARY" \
   --grep "$TOPIC")
 
 # Supplement with official docs if URL known
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python -m runtime.harness scripts/mcp/firecrawl_scrape.py \
+(cd $CLAUDE_OPC_DIR && uv run python -m runtime.harness scripts/mcp/firecrawl_scrape.py \
   --url "https://docs.example.com/api/$TOPIC" \
   --format markdown)
 ```
@@ -192,26 +192,26 @@ Primary tool: **perplexity-search** - Find recommended approaches, patterns, ant
 
 ```bash
 # AI-synthesized research (sonar-pro)
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/mcp/perplexity_search.py \
   --research "$TOPIC best practices 2024 2025")
 
 # If comparing alternatives
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/mcp/perplexity_search.py \
   --reason "$TOPIC vs alternatives - which to choose?")
 ```
 
 **Thorough depth additions:**
 ```bash
 # Chain-of-thought for complex decisions
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/mcp/perplexity_search.py \
   --reason "$TOPIC tradeoffs and considerations 2025")
 
 # Deep comprehensive research
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/mcp/perplexity_search.py \
   --deep "$TOPIC comprehensive guide 2025")
 
 # Recent developments
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/mcp/perplexity_search.py \
   --search "$TOPIC latest developments" \
   --recency month --max-results 5)
 ```
@@ -222,20 +222,20 @@ Use ALL available MCP tools - comprehensive multi-source research.
 
 **Step 2a: Library documentation (nia-docs)**
 ```bash
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python -m runtime.harness scripts/mcp/nia_docs.py \
+(cd $CLAUDE_OPC_DIR && uv run python -m runtime.harness scripts/mcp/nia_docs.py \
   --search "$TOPIC")
 ```
 
 **Step 2b: Web research (perplexity)**
 ```bash
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/mcp/perplexity_search.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/mcp/perplexity_search.py \
   --research "$TOPIC")
 ```
 
 **Step 2c: Specific documentation (firecrawl)**
 ```bash
 # Scrape relevant documentation pages found in perplexity results
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python -m runtime.harness scripts/mcp/firecrawl_scrape.py \
+(cd $CLAUDE_OPC_DIR && uv run python -m runtime.harness scripts/mcp/firecrawl_scrape.py \
   --url "$FOUND_DOC_URL" \
   --format markdown)
 ```

--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,8 @@ Skill activation triggers.
 | `BRAINTRUST_API_KEY` | Session tracing | No |
 | `PERPLEXITY_API_KEY` | Web search | No |
 | `NIA_API_KEY` | Documentation search | No |
+| `CLAUDE_OPC_DIR` | Path to CC's opc/ directory (set by wizard) | Auto |
+| `CLAUDE_PROJECT_DIR` | Current project directory (set by SessionStart hook) | Auto |
 
 Services without API keys still work:
 - Continuity system (ledgers, handoffs)


### PR DESCRIPTION
## Problem

CC skills like `/perplexity-search`, `/recall`, `/research-external` use the wrong Python virtual environment because:

1. Skills use `cd $CLAUDE_PROJECT_DIR/opc && uv run ...`
2. `CLAUDE_PROJECT_DIR` is never set - the SessionStart hook that should set it has a circular dependency: the hook path uses `$CLAUDE_PROJECT_DIR` before the variable exists
3. Even if fixed, the hook would set `CLAUDE_PROJECT_DIR` to the "current project directory", not the "CC installation directory"
4. When unset, `uv run` finds whatever `.venv` exists in the current working directory tree instead of CC's `opc/.venv`

## Root Cause

Semantic confusion between two different concepts:
- `CLAUDE_PROJECT_DIR` = current project directory (dynamic, per-session)
- CC installation directory = where opc/.venv lives (static, global)

Skills were using `$CLAUDE_PROJECT_DIR/opc` as if it meant "CC installation", but the variable name suggests "current project".

## Solution

1. **Add CLAUDE_OPC_DIR to wizard** - The wizard now exports `CLAUDE_OPC_DIR` to bashrc/zshrc, pointing to the CC `opc/` directory where `.venv` lives. This matches the existing TypeScript hooks (opc-path.ts) which already support `CLAUDE_OPC_DIR` as first priority.

2. **Update skills/rules** - Changed 22 occurrences of `$CLAUDE_PROJECT_DIR/opc` to `$CLAUDE_OPC_DIR` in rules and skills that run Python scripts.

3. **Fix hook circular dependency** - Changed persist-project-dir.sh hook path from `$CLAUDE_PROJECT_DIR/.claude/hooks/...` to `$HOME/.claude/hooks/...` so the hook can actually run and set `CLAUDE_PROJECT_DIR` to the current project directory (its intended purpose).

4. **Document variables** - Added both variables to README.md with clear descriptions of their purposes and how they're set.

## Files Changed

- opc/scripts/setup/wizard.py: Add CLAUDE_OPC_DIR export to shell config
- .claude/settings.json: Fix hook path circular dependency
- .claude/rules/dynamic-recall.md: 7 replacements
- .claude/rules/agent-memory-recall.md: 1 replacement
- .claude/rules/proactive-delegation.md: 1 replacement
- .claude/skills/recall/SKILL.md: 1 replacement
- .claude/skills/remember/SKILL.md: 1 replacement
- .claude/skills/research-external/SKILL.md: 11 replacements
- README.md: Document CLAUDE_OPC_DIR and CLAUDE_PROJECT_DIR

## Testing

After this change:
1. Run wizard or manually `export CLAUDE_OPC_DIR="/path/to/CC/opc"`
2. Skills like `/recall` and `/perplexity-search` will use correct venv
3. `CLAUDE_PROJECT_DIR` can be set per-session to current project (optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now offers to set CLAUDE_OPC_DIR automatically for skills during setup.

* **Documentation**
  * Added CLAUDE_OPC_DIR and CLAUDE_PROJECT_DIR to README environment variables.

* **Chores**
  * Standardized references to the OPC directory across docs and examples.
  * Adjusted session startup hook to use a user-home based path where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->