### PR TITLE
fix: correct script path references in skills and agents

### DIFF
--- a/.claude/agents/agentica-agent.md
+++ b/.claude/agents/agentica-agent.md
@@ -14,7 +14,7 @@ You are a specialized agent for building Python agents using the Agentica SDK. Y
 Before starting, read the SDK skill for full API reference:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/skills/agentica-sdk/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/agentica-sdk/SKILL.md
 ```
 
 ## Step 2: Understand Your Task

--- a/.claude/agents/braintrust-analyst.md
+++ b/.claude/agents/braintrust-analyst.md
@@ -19,7 +19,7 @@ You are a specialized analysis agent. Your job is to run Braintrust analysis scr
 Read the braintrust-analyze skill:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/skills/braintrust-analyze/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/braintrust-analyze/SKILL.md
 ```
 
 ## Step 2: Execute Analysis
@@ -27,7 +27,7 @@ cat $CLAUDE_PROJECT_DIR/.claude/skills/braintrust-analyze/SKILL.md
 Run analysis IMMEDIATELY using Bash tool:
 
 ```bash
-cd $CLAUDE_PROJECT_DIR && uv run python -m runtime.harness scripts/braintrust_analyze.py --last-session
+cd $CLAUDE_OPC_DIR && uv run python -m runtime.harness scripts/braintrust_analyze.py --last-session
 ```
 
 Other analyses (run as needed):

--- a/.claude/agents/debug-agent.md
+++ b/.claude/agents/debug-agent.md
@@ -13,7 +13,7 @@ You are a specialized debugging agent. Your job is to investigate issues, trace 
 Before starting, read the debug skill for methodology:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/skills/debug/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/debug/SKILL.md
 ```
 
 Follow the structure and guidelines from that skill.

--- a/.claude/agents/memory-extractor.md
+++ b/.claude/agents/memory-extractor.md
@@ -31,7 +31,7 @@ You receive:
 
 ```bash
 # Use the extraction script with filtering
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/core/extract_thinking_blocks.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/core/extract_thinking_blocks.py \
   --jsonl "$JSONL_PATH" \
   --filter \
   --format json) > /tmp/perception-blocks.json
@@ -42,7 +42,7 @@ This extracts only thinking blocks containing perception signals (actually, real
 ### Step 2: Check Stats
 
 ```bash
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/core/extract_thinking_blocks.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/core/extract_thinking_blocks.py \
   --jsonl "$JSONL_PATH" \
   --stats)
 ```
@@ -80,7 +80,7 @@ For each extracted perception change, use the mapped type from Step 3:
 
 ```bash
 # Example for a CORRECTION → ERROR_FIX
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/core/store_learning.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/core/store_learning.py \
   --session-id "$SESSION_ID" \
   --type "ERROR_FIX" \
   --context "what this relates to" \
@@ -90,7 +90,7 @@ For each extracted perception change, use the mapped type from Step 3:
   --json)
 
 # Example for a REALIZATION/INSIGHT → CODEBASE_PATTERN
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/core/store_learning.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/core/store_learning.py \
   --session-id "$SESSION_ID" \
   --type "CODEBASE_PATTERN" \
   --context "what this relates to" \
@@ -100,7 +100,7 @@ For each extracted perception change, use the mapped type from Step 3:
   --json)
 
 # Example for a DEBUGGING_APPROACH → WORKING_SOLUTION
-(cd $CLAUDE_PROJECT_DIR/opc && uv run python scripts/core/store_learning.py \
+(cd $CLAUDE_OPC_DIR && uv run python scripts/core/store_learning.py \
   --session-id "$SESSION_ID" \
   --type "WORKING_SOLUTION" \
   --context "debugging methodology" \

--- a/.claude/agents/plan-agent.md
+++ b/.claude/agents/plan-agent.md
@@ -13,7 +13,7 @@ You are a specialized planning agent. Your job is to create detailed implementat
 Before creating any plan, read the planning skill for methodology and format:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/skills/create_plan/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/create_plan/SKILL.md
 ```
 
 Follow the structure and guidelines from that skill.

--- a/.claude/agents/scribe.md
+++ b/.claude/agents/scribe.md
@@ -15,10 +15,10 @@ Before creating documentation, read the relevant skills:
 
 ```bash
 # For handoffs
-cat $CLAUDE_PROJECT_DIR/.claude/skills/create_handoff/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/create_handoff/SKILL.md
 
 # For ledger updates
-cat $CLAUDE_PROJECT_DIR/.claude/skills/continuity_ledger/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/continuity_ledger/SKILL.md
 ```
 
 Follow the structure and guidelines from those skills.

--- a/.claude/agents/session-analyst.md
+++ b/.claude/agents/session-analyst.md
@@ -13,7 +13,7 @@ You analyze Claude Code session data from Braintrust and provide insights.
 Read the skill file first:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/skills/braintrust-analyze/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/braintrust-analyze/SKILL.md
 ```
 
 ## Step 2: Run Analysis
@@ -21,7 +21,7 @@ cat $CLAUDE_PROJECT_DIR/.claude/skills/braintrust-analyze/SKILL.md
 Run the appropriate command based on user request:
 
 ```bash
-cd $CLAUDE_PROJECT_DIR
+cd $CLAUDE_OPC_DIR
 uv run python -m runtime.harness scripts/braintrust_analyze.py --last-session
 ```
 

--- a/.claude/agents/validate-agent.md
+++ b/.claude/agents/validate-agent.md
@@ -13,7 +13,7 @@ You are a specialized validation agent. Your job is to validate a technical plan
 Before validating, read the validation skill for methodology and format:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/skills/validate-agent/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/validate-agent/SKILL.md
 ```
 
 Follow the structure and guidelines from that skill.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -32,7 +32,7 @@ You are tasked with creating git commits for the changes made during this sessio
    - Show the result with `git log --oneline -n [number]`
 
 5. **Generate reasoning (after each commit):**
-   - Run: `bash "$CLAUDE_PROJECT_DIR/.claude/scripts/generate-reasoning.sh" <commit-hash> "<commit-message>"`
+   - Run: `bash "$CLAUDE_CC_DIR/.claude/scripts/generate-reasoning.sh" <commit-hash> "<commit-message>"`
    - This captures what was tried during development (build failures, fixes)
    - The reasoning file helps future sessions understand past decisions
    - Stored in `.git/claude/commits/<hash>/reasoning.md`

--- a/.claude/skills/commit/SKILL.v6.md
+++ b/.claude/skills/commit/SKILL.v6.md
@@ -71,7 +71,7 @@ eta |-> generate_reasoning(hash, message)
 ```bash
 git add <file1> <file2> ...
 git commit -m "message"
-bash "$CLAUDE_PROJECT_DIR/.claude/scripts/generate-reasoning.sh" <hash> "<message>"
+bash "$CLAUDE_CC_DIR/.claude/scripts/generate-reasoning.sh" <hash> "<message>"
 git log --oneline -n N
 ```
 

--- a/.claude/skills/describe_pr/SKILL.md
+++ b/.claude/skills/describe_pr/SKILL.md
@@ -34,7 +34,7 @@ You are tasked with generating a comprehensive pull request description followin
 
 4b. **Gather reasoning history (if available):**
    - Check if reasoning files exist: `ls .git/claude/commits/*/reasoning.md 2>/dev/null`
-   - If they exist, aggregate them: `bash "$CLAUDE_PROJECT_DIR/.claude/scripts/aggregate-reasoning.sh" main`
+   - If they exist, aggregate them: `bash "$CLAUDE_CC_DIR/.claude/scripts/aggregate-reasoning.sh" main`
    - This shows what approaches were tried before the final solution
    - Save the output for inclusion in the PR description
 

--- a/.claude/skills/git-commits/SKILL.md
+++ b/.claude/skills/git-commits/SKILL.md
@@ -38,7 +38,7 @@ When you see these in user prompts, use the commit skill:
 
 The skill will prompt you to run:
 ```bash
-bash "$CLAUDE_PROJECT_DIR/.claude/scripts/generate-reasoning.sh" <hash> "<message>"
+bash "$CLAUDE_CC_DIR/.claude/scripts/generate-reasoning.sh" <hash> "<message>"
 ```
 
 Then push if requested:

--- a/.claude/skills/math-unified/SKILL.md
+++ b/.claude/skills/math-unified/SKILL.md
@@ -31,7 +31,7 @@ For formal proofs, use `/prove` instead.
 
 ### SymPy (Symbolic Math)
 ```bash
-uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/sympy_compute.py" <command> <args>
+uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/sympy_compute.py" <command> <args>
 ```
 
 | Command | Description | Example |
@@ -83,7 +83,7 @@ uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/sympy_compute.py" <co
 
 ### Z3 (Constraint Solving)
 ```bash
-uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/z3_solve.py" <command> <args>
+uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/z3_solve.py" <command> <args>
 ```
 
 | Command | Use Case |
@@ -96,7 +96,7 @@ uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/z3_solve.py" <command
 
 ### Pint (Units)
 ```bash
-uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/pint_compute.py" convert <value> <from_unit> <to_unit>
+uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/pint_compute.py" convert <value> <from_unit> <to_unit>
 ```
 
 Example: `convert 5 miles kilometers`
@@ -105,7 +105,7 @@ Example: `convert 5 miles kilometers`
 
 ### Math Router (Auto-Route)
 ```bash
-uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/math_router.py" route "<natural language request>"
+uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/math_router.py" route "<natural language request>"
 ```
 
 Returns the exact command to run. Use when unsure which script.
@@ -154,28 +154,28 @@ I decide based on your request:
 ### Solve Equation
 ```
 User: Solve x² - 5x + 6 = 0
-Claude: uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/sympy_compute.py" solve "x**2 - 5*x + 6" --var x
+Claude: uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/sympy_compute.py" solve "x**2 - 5*x + 6" --var x
 Result: x = 2 or x = 3
 ```
 
 ### Compute Eigenvalues
 ```
 User: Find eigenvalues of [[2, 1], [1, 2]]
-Claude: uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/sympy_compute.py" eigenvalues "[[2,1],[1,2]]"
+Claude: uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/sympy_compute.py" eigenvalues "[[2,1],[1,2]]"
 Result: {1: 1, 3: 1}  (eigenvalue 1 with multiplicity 1, eigenvalue 3 with multiplicity 1)
 ```
 
 ### Prove Inequality
 ```
 User: Is x² + y² ≥ 2xy always true?
-Claude: uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/z3_solve.py" prove "x**2 + y**2 >= 2*x*y"
+Claude: uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/z3_solve.py" prove "x**2 + y**2 >= 2*x*y"
 Result: PROVED (equivalent to (x-y)² ≥ 0)
 ```
 
 ### Convert Units
 ```
 User: How many kilometers in 26.2 miles?
-Claude: uv run python "$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/pint_compute.py" convert 26.2 miles kilometers
+Claude: uv run python "$CLAUDE_OPC_DIR/scripts/cc_math/pint_compute.py" convert 26.2 miles kilometers
 Result: 42.16 km
 ```
 

--- a/.claude/skills/recall-reasoning/SKILL.md
+++ b/.claude/skills/recall-reasoning/SKILL.md
@@ -32,7 +32,7 @@ This searches handoffs with post-mortems (what worked, what failed, key decision
 ### Secondary: Reasoning Files (build attempts)
 
 ```bash
-bash "$CLAUDE_PROJECT_DIR/.claude/scripts/search-reasoning.sh" "<query>"
+bash "$CLAUDE_CC_DIR/.claude/scripts/search-reasoning.sh" "<query>"
 ```
 
 This searches `.git/claude/commits/*/reasoning.md` for build failures and fixes.
@@ -50,7 +50,7 @@ uv run python scripts/core/artifact_query.py "implement agent" --outcome SUCCEED
 uv run python scripts/core/artifact_query.py "hook implementation" --outcome FAILED
 
 # Search build/test reasoning
-bash "$CLAUDE_PROJECT_DIR/.claude/scripts/search-reasoning.sh" "TypeError"
+bash "$CLAUDE_CC_DIR/.claude/scripts/search-reasoning.sh" "TypeError"
 ```
 
 ## What Gets Searched

--- a/.claude/skills/skill-developer/SKILL.md
+++ b/.claude/skills/skill-developer/SKILL.md
@@ -56,14 +56,14 @@ To create a new MCP chain script and wrap it as a skill:
 Copy the multi-tool-pipeline template:
 
 ```bash
-cp $CLAUDE_PROJECT_DIR/scripts/multi_tool_pipeline.py $CLAUDE_PROJECT_DIR/scripts/my_pipeline.py
+cp $CLAUDE_OPC_DIR/scripts/multi_tool_pipeline.py $CLAUDE_OPC_DIR/scripts/my_pipeline.py
 ```
 
 Reference the template pattern:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/skills/multi-tool-pipeline/SKILL.md
-cat $CLAUDE_PROJECT_DIR/scripts/multi_tool_pipeline.py
+cat $CLAUDE_CC_DIR/.claude/skills/multi-tool-pipeline/SKILL.md
+cat $CLAUDE_OPC_DIR/scripts/multi_tool_pipeline.py
 ```
 
 ### Step 2: Customize the Script
@@ -140,8 +140,8 @@ Add to `.claude/skills/skill-rules.json`:
 For full details, read:
 
 ```bash
-cat $CLAUDE_PROJECT_DIR/.claude/rules/skill-development.md
-cat $CLAUDE_PROJECT_DIR/.claude/rules/mcp-scripts.md
+cat $CLAUDE_CC_DIR/.claude/rules/skill-development.md
+cat $CLAUDE_CC_DIR/.claude/rules/mcp-scripts.md
 ```
 
 ## Quick Checklist
@@ -157,7 +157,7 @@ cat $CLAUDE_PROJECT_DIR/.claude/rules/mcp-scripts.md
 Look at existing skills for patterns:
 
 ```bash
-ls $CLAUDE_PROJECT_DIR/.claude/skills/
-cat $CLAUDE_PROJECT_DIR/.claude/skills/commit/SKILL.md
-cat $CLAUDE_PROJECT_DIR/.claude/skills/firecrawl-scrape/SKILL.md
+ls $CLAUDE_CC_DIR/.claude/skills/
+cat $CLAUDE_CC_DIR/.claude/skills/commit/SKILL.md
+cat $CLAUDE_CC_DIR/.claude/skills/firecrawl-scrape/SKILL.md
 ```

--- a/.claude/skills/tldr-stats/SKILL.md
+++ b/.claude/skills/tldr-stats/SKILL.md
@@ -20,7 +20,7 @@ Show a beautiful dashboard with token usage, actual API costs, TLDR savings, and
 
 1. Run the stats script:
 ```bash
-python3 $CLAUDE_PROJECT_DIR/.claude/scripts/tldr_stats.py
+python3 $CLAUDE_CC_DIR/.claude/scripts/tldr_stats.py
 ```
 
 2. **Copy the full output into your response** so the user sees the dashboard directly in the chat. Do not just run the command silently - the user wants to see the stats.

--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -836,8 +836,10 @@ async def run_setup_wizard() -> None:
         else:
             console.print("  Skipped integration installation")
 
-    # Set CLAUDE_OPC_DIR environment variable for skills to find scripts
-    console.print("  Setting CLAUDE_OPC_DIR environment variable...")
+    # Set CLAUDE_OPC_DIR and CLAUDE_CC_DIR environment variables
+    # CLAUDE_OPC_DIR = opc/ directory (Python scripts, MCP runtime)
+    # CLAUDE_CC_DIR  = repository root (contains .claude/scripts/, .claude/skills/)
+    console.print("  Setting environment variables...")
     shell_config = None
     shell = os.environ.get("SHELL", "")
     if "zsh" in shell:
@@ -846,21 +848,32 @@ async def run_setup_wizard() -> None:
         shell_config = Path.home() / ".bashrc"
 
     opc_dir = _project_root  # Use script location, not cwd (robust if invoked from elsewhere)
+    cc_dir = opc_dir.parent   # Repository root (Continuous-Claude-v3/)
     if shell_config and shell_config.exists():
         content = shell_config.read_text()
-        export_line = f'export CLAUDE_OPC_DIR="{opc_dir}"'
+        changed = False
+        export_opc = f'export CLAUDE_OPC_DIR="{opc_dir}"'
+        export_cc = f'export CLAUDE_CC_DIR="{cc_dir}"'
         if "CLAUDE_OPC_DIR" not in content:
             with open(shell_config, "a") as f:
-                f.write(f"\n# Continuous-Claude OPC directory (for skills to find scripts)\n{export_line}\n")
-            console.print(f"  [green]OK[/green] Added CLAUDE_OPC_DIR to {shell_config.name}")
+                f.write(f"\n# Continuous-Claude directories (for skills to find scripts)\n{export_opc}\n{export_cc}\n")
+            changed = True
+        elif "CLAUDE_CC_DIR" not in content:
+            with open(shell_config, "a") as f:
+                f.write(f"\n# Continuous-Claude root directory\n{export_cc}\n")
+            changed = True
+        if changed:
+            console.print(f"  [green]OK[/green] Added CLAUDE_OPC_DIR and CLAUDE_CC_DIR to {shell_config.name}")
         else:
-            console.print(f"  [dim]CLAUDE_OPC_DIR already in {shell_config.name}[/dim]")
+            console.print(f"  [dim]CLAUDE_OPC_DIR and CLAUDE_CC_DIR already in {shell_config.name}[/dim]")
     elif sys.platform == "win32":
         console.print("  [yellow]NOTE[/yellow] Add to your environment:")
         console.print(f'       set CLAUDE_OPC_DIR="{opc_dir}"')
+        console.print(f'       set CLAUDE_CC_DIR="{cc_dir}"')
     else:
         console.print("  [yellow]NOTE[/yellow] Add to your shell config:")
         console.print(f'       export CLAUDE_OPC_DIR="{opc_dir}"')
+        console.print(f'       export CLAUDE_CC_DIR="{cc_dir}"')
 
     # Step 8: Math Features (Optional)
     console.print("\n[bold]Step 9/13: Math Features (Optional)[/bold]")


### PR DESCRIPTION
## Summary

- Added `CLAUDE_CC_DIR` environment variable export in wizard (CC repository root)
- Updated 7 skills and 8 agents to use `$CLAUDE_CC_DIR` or `$CLAUDE_OPC_DIR` instead of `$CLAUDE_PROJECT_DIR` for CC-internal script references

## Problem

`$CLAUDE_PROJECT_DIR` is set by Claude Code to the **user's current working project** (e.g. `/Users/x/myapp`). Multiple skills and agents use it to locate CC's own scripts (e.g. `generate-reasoning.sh`, `cc_math/*.py`), which only works if the user happens to be working inside the CC repo itself.

For any other project, scripts are not found:
```
bash "$CLAUDE_PROJECT_DIR/.claude/scripts/generate-reasoning.sh" ...
# Expands to: /Users/x/myapp/.claude/scripts/generate-reasoning.sh
# But script is at: /Users/x/Continuous-Claude-v3/.claude/scripts/generate-reasoning.sh
```

## Fix

- Wizard now exports `CLAUDE_CC_DIR` (CC repo root = parent of `CLAUDE_OPC_DIR`)
- Skills use `$CLAUDE_CC_DIR/.claude/scripts/` for shell scripts
- Skills use `$CLAUDE_OPC_DIR/scripts/` for Python scripts (cc_math, etc.)
- Agents use `$CLAUDE_CC_DIR` for skill file reads and `$CLAUDE_OPC_DIR` for runtime scripts

### Path mapping

| Old path | New path | Used for |
|----------|----------|----------|
| `$CLAUDE_PROJECT_DIR/.claude/scripts/*.sh` | `$CLAUDE_CC_DIR/.claude/scripts/*.sh` | Reasoning scripts |
| `$CLAUDE_PROJECT_DIR/.claude/scripts/cc_math/` | `$CLAUDE_OPC_DIR/scripts/cc_math/` | Math compute scripts |
| `$CLAUDE_PROJECT_DIR/.claude/scripts/tldr_stats.py` | `$CLAUDE_CC_DIR/.claude/scripts/tldr_stats.py` | Stats script |
| `$CLAUDE_PROJECT_DIR/.claude/skills/*/SKILL.md` | `$CLAUDE_CC_DIR/.claude/skills/*/SKILL.md` | Agent skill reads |
| `$CLAUDE_PROJECT_DIR/opc` | `$CLAUDE_OPC_DIR` | OPC runtime scripts |

## Files changed (17)

**Wizard:** `opc/scripts/setup/wizard.py` — add `CLAUDE_CC_DIR` export

**Skills (7):** commit, commit/v6, git-commits, describe_pr, recall-reasoning, tldr-stats, math-unified, skill-developer

**Agents (8):** braintrust-analyst, session-analyst, memory-extractor, agentica-agent, plan-agent, validate-agent, scribe, debug-agent

## Test plan

- [ ] Run wizard — verify both `CLAUDE_CC_DIR` and `CLAUDE_OPC_DIR` are exported to shell config
- [ ] From a non-CC project, run `/commit` — verify `generate-reasoning.sh` is found
- [ ] From a non-CC project, run `/tldr-stats` — verify `tldr_stats.py` is found
- [ ] Verify `echo $CLAUDE_CC_DIR` and `echo $CLAUDE_OPC_DIR` are set after sourcing shell config

Fixes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable path references throughout the system for improved directory organization
  * Enhanced setup wizard to automatically configure multiple environment variables during initial setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->