### PR TITLE
fix: correct README clone URL, Star History link, and Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,8 +1015,8 @@ Blocks on HIGH severity until user accepts/mitigates risks.
 
 ```bash
 # Clone
-git clone https://github.com/parcadei/continuous-claude.git
-cd continuous-claude/opc
+git clone https://github.com/parcadei/Continuous-Claude-v3.git
+cd Continuous-Claude-v3/opc
 
 # Run the setup wizard
 uv run python -m scripts.setup.wizard
@@ -1260,7 +1260,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
 - **[yoloshii/mcp-code-execution-enhanced](https://github.com/yoloshii/mcp-code-execution-enhanced)** - Enhanced MCP execution
 - **[HumanLayer](https://github.com/humanlayer/humanlayer)** - Agent patterns
 
-### Tools & Services
+### Tools & Services (Optional Integrations)
+
+> These tools enhance specific skills but are **not required** for core functionality.
+> The setup wizard installs only the essentials (Docker, Python 3.11+, uv).
+
 - **[uv](https://github.com/astral-sh/uv)** - Python packaging
 - **[tree-sitter](https://tree-sitter.github.io/)** - Code parsing
 - **[Braintrust](https://braintrust.dev)** - LLM evaluation, logging, and session tracing
@@ -1275,7 +1279,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=parcadei/Continuous-Claude-v2&type=timeline)](https://star-history.com/#parcadei/Continuous-Claude-v2&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=parcadei/Continuous-Claude-v3&type=timeline)](https://star-history.com/#parcadei/Continuous-Claude-v3&Date)
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix Installation section clone URL (`continuous-claude` → `Continuous-Claude-v3`) — was 404ing or cloning wrong repo
- Fix Star History chart pointing to `Continuous-Claude-v2` instead of `Continuous-Claude-v3`
- Add "Optional Integrations" note to Tools & Services section to clarify these aren't required

## Changes

| Line | Before | After |
|------|--------|-------|
| 1018-1019 | `parcadei/continuous-claude.git` | `parcadei/Continuous-Claude-v3.git` |
| 1278 | `parcadei/Continuous-Claude-v2` | `parcadei/Continuous-Claude-v3` |
| 1263 | `### Tools & Services` | `### Tools & Services (Optional Integrations)` + note |

Closes #139

## Test plan

- [ ] Verify clone URL works: `git clone https://github.com/parcadei/Continuous-Claude-v3.git`
- [ ] Verify Star History chart loads correctly
- [ ] Verify Tools section note renders properly in GitHub markdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and repository references to v3.
  * Reorganized Tools & Services section to clarify optional integrations.
  * Expanded available tool options for enhanced functionality.
  * Updated image links and version references throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->