### PR TITLE
feat: add Firecrawl API key to setup wizard

### DIFF
--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -407,7 +407,7 @@ async def prompt_api_keys() -> dict[str, str]:
     """Prompt user for optional API keys.
 
     Returns:
-        dict with keys: perplexity, nia, braintrust
+        dict with keys: perplexity, nia, braintrust, firecrawl
     """
     console.print("\n[bold]API Keys (optional)[/bold]")
     console.print("Press Enter to skip any key you don't have.\n")
@@ -415,11 +415,13 @@ async def prompt_api_keys() -> dict[str, str]:
     perplexity = Prompt.ask("Perplexity API key (web search)", default="")
     nia = Prompt.ask("Nia API key (documentation search)", default="")
     braintrust = Prompt.ask("Braintrust API key (observability)", default="")
+    firecrawl = Prompt.ask("Firecrawl API key (web scraping)", default="")
 
     return {
         "perplexity": perplexity,
         "nia": nia,
         "braintrust": braintrust,
+        "firecrawl": firecrawl,
     }
 
 
@@ -500,6 +502,8 @@ def generate_env_file(config: dict[str, Any], env_path: Path) -> None:
                 lines.append(f"NIA_API_KEY={api_keys['nia']}")
             if api_keys.get("braintrust"):
                 lines.append(f"BRAINTRUST_API_KEY={api_keys['braintrust']}")
+            if api_keys.get("firecrawl"):
+                lines.append(f"FIRECRAWL_API_KEY={api_keys['firecrawl']}")
             lines.append("")
 
     # Write file

--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -620,7 +620,7 @@ async def run_setup_wizard() -> None:
     if Confirm.ask("Configure API keys?", default=False):
         api_keys = await prompt_api_keys()
     else:
-        api_keys = {"perplexity": "", "nia": "", "braintrust": ""}
+        api_keys = {"perplexity": "", "nia": "", "braintrust": "", "firecrawl": ""}
 
     # Step 5: Generate .env
     console.print("\n[bold]Step 5/13: Generating configuration...[/bold]")


### PR DESCRIPTION
## Summary

Add Firecrawl API key prompt to the setup wizard's `prompt_api_keys()` function.

Currently the wizard prompts for Perplexity, Nia, and Braintrust but skips Firecrawl, which is needed by 3 skills.

## Changes

- `prompt_api_keys()` — add `Firecrawl API key (web scraping)` prompt
- `generate_env_file()` — write `FIRECRAWL_API_KEY` to `.env`

## Skills unlocked

| Skill | Impact when Firecrawl missing |
|-------|------------------------------|
| `firecrawl-scrape` | **Broken** — cannot scrape web pages |
| `research-agent` | **Degraded** — loses doc scraping |
| `research-external` | **Degraded** — skips doc scraping phase |

API key from: https://www.firecrawl.dev

## Test plan

- [ ] Run wizard → Step 4 now shows Firecrawl prompt
- [ ] Enter key → verify `FIRECRAWL_API_KEY=xxx` appears in `.env`
- [ ] Skip (Enter) → verify no `FIRECRAWL_API_KEY` line in `.env`

Ref #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup wizard now supports adding a Firecrawl API key during onboarding.
  * Provided Firecrawl key is automatically written to the environment configuration file.
  * Wizard defaults include an empty Firecrawl API key slot so it can be configured later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->