### PR TITLE
feat: add Morph API key to setup wizard

### DIFF
--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -407,7 +407,7 @@ async def prompt_api_keys() -> dict[str, str]:
     """Prompt user for optional API keys.
 
     Returns:
-        dict with keys: perplexity, nia, braintrust
+        dict with keys: perplexity, nia, braintrust, morph
     """
     console.print("\n[bold]API Keys (optional)[/bold]")
     console.print("Press Enter to skip any key you don't have.\n")
@@ -415,11 +415,13 @@ async def prompt_api_keys() -> dict[str, str]:
     perplexity = Prompt.ask("Perplexity API key (web search)", default="")
     nia = Prompt.ask("Nia API key (documentation search)", default="")
     braintrust = Prompt.ask("Braintrust API key (observability)", default="")
+    morph = Prompt.ask("Morph API key (fast code editing/search)", default="")
 
     return {
         "perplexity": perplexity,
         "nia": nia,
         "braintrust": braintrust,
+        "morph": morph,
     }
 
 
@@ -500,6 +502,8 @@ def generate_env_file(config: dict[str, Any], env_path: Path) -> None:
                 lines.append(f"NIA_API_KEY={api_keys['nia']}")
             if api_keys.get("braintrust"):
                 lines.append(f"BRAINTRUST_API_KEY={api_keys['braintrust']}")
+            if api_keys.get("morph"):
+                lines.append(f"MORPH_API_KEY={api_keys['morph']}")
             lines.append("")
 
     # Write file


### PR DESCRIPTION
## Summary

Add Morph API key prompt to the setup wizard's `prompt_api_keys()` function.

Currently the wizard prompts for Perplexity, Nia, and Braintrust but skips Morph, which is needed by 3 skills.

## Changes

- `prompt_api_keys()` — add `Morph API key (fast code editing/search)` prompt
- `generate_env_file()` — write `MORPH_API_KEY` to `.env`

## Skills unlocked

| Skill | Impact when Morph missing |
|-------|--------------------------|
| `morph-apply` | **Broken** — cannot use fast AI file editing (10,500 tokens/sec) |
| `morph-search` | **Broken** — cannot use WarpGrep fast search (20x faster) |
| `implement_task` | **Degraded** — falls back to native Edit tool |

API key from: https://www.morphllm.com

## Test plan

- [ ] Run wizard → Step 4 now shows Morph prompt
- [ ] Enter key → verify `MORPH_API_KEY=xxx` appears in `.env`
- [ ] Skip (Enter) → verify no `MORPH_API_KEY` line in `.env`

Ref #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Morph API key configuration to the setup wizard, enabling users to provide and store their Morph API key during the initial setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->