### PR TITLE
fix: improve uninstall wizard cleanup

### DIFF
--- a/opc/scripts/setup/claude_integration.py
+++ b/opc/scripts/setup/claude_integration.py
@@ -812,10 +812,11 @@ def find_latest_backup(claude_dir: Path) -> Path | None:
 
 # Files to preserve during uninstall (user data accumulated since install)
 PRESERVE_FILES = [
-    "history.jsonl",      # Command history
-    "mcp_config.json",    # MCP server configs
-    ".env",               # API keys and settings
-    "projects.json",      # Project configs
+    "history.jsonl",        # Command history
+    "mcp_config.json",      # MCP server configs
+    ".env",                 # API keys and settings
+    "projects.json",        # Project configs
+    "settings.local.json",  # User's custom permissions and overrides
 ]
 
 PRESERVE_DIRS = [
@@ -918,8 +919,8 @@ def uninstall_opc_integration(
                 else:
                     shutil.copy2(archived_src, dest)
                 result["preserved"].append(name)
-            except Exception:
-                pass  # Best effort
+            except Exception as e:
+                result.setdefault("preserve_warnings", []).append(f"{name}: {e}")
 
     # Build summary message
     msg_parts = ["Uninstalled successfully."]
@@ -930,6 +931,9 @@ def uninstall_opc_integration(
         msg_parts.append("  No backup found (created empty .claude)")
     if result["preserved"]:
         msg_parts.append(f"  Preserved user data: {', '.join(result['preserved'])}")
+    if result.get("preserve_warnings"):
+        for warning in result["preserve_warnings"]:
+            msg_parts.append(f"  [WARN] Could not preserve {warning}")
 
     result["message"] = "\n".join(msg_parts)
     result["success"] = True

--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -1353,16 +1353,20 @@ async def run_uninstall_wizard() -> None:
         if Confirm.ask("\n  Remove TLDR CLI tool?", default=False):
             import subprocess
 
-            remove_result = subprocess.run(
-                ["uv", "tool", "uninstall", "llm-tldr"],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if remove_result.returncode == 0:
-                console.print("  [green]OK[/green] TLDR removed")
-            else:
-                console.print("  [yellow]WARN[/yellow] Could not remove TLDR")
+            try:
+                remove_result = subprocess.run(
+                    ["uv", "tool", "uninstall", "llm-tldr"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if remove_result.returncode == 0:
+                    console.print("  [green]OK[/green] TLDR removed")
+                else:
+                    console.print("  [yellow]WARN[/yellow] Could not remove TLDR")
+                    console.print("  Remove manually: uv tool uninstall llm-tldr")
+            except (subprocess.TimeoutExpired, OSError) as e:
+                console.print(f"  [yellow]WARN[/yellow] Could not remove TLDR: {e}")
                 console.print("  Remove manually: uv tool uninstall llm-tldr")
 
 


### PR DESCRIPTION
## Summary

The uninstall wizard archives `~/.claude` and restores backup, but leaves several artifacts behind. This PR fixes that.

## Changes

### claude_integration.py
- **Add `settings.local.json` to `PRESERVE_FILES`** — users store custom permissions here; was being lost on uninstall
- **Log preserve warnings** — instead of `except Exception: pass`, now records which files failed to preserve and includes them in the summary message

### wizard.py
- **Remove `CLAUDE_OPC_DIR` from shell config** — the install wizard adds `export CLAUDE_OPC_DIR=...` to `~/.zshrc`/`~/.bashrc` but uninstall never cleaned it up
- **Offer to remove TLDR CLI** — `uv tool uninstall llm-tldr` (default: No, since user might want to keep it)

### Not included (intentionally)
- **Docker container cleanup** — removed from scope; users may share containers with other projects

## Test plan

- [ ] Run `--uninstall` with `CLAUDE_OPC_DIR` in `~/.zshrc` → verify it's removed
- [ ] Run `--uninstall` with `settings.local.json` present → verify it's preserved
- [ ] Simulate preserve failure → verify warning appears in output instead of silent pass
- [ ] Run `--uninstall` with TLDR installed → verify removal prompt appears
- [ ] Decline TLDR removal → verify it stays installed

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files are now preserved during uninstall
  * Shell configuration exports are automatically removed during uninstall
  * Optional cleanup for related tools offered during uninstall

* **Bug Fixes**
  * Enhanced error reporting during configuration preservation with warning messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->