### PR TITLE
fix: tldr-read-enforcer hook ignored when Claude uses a relative file path

### DIFF
--- a/.claude/hooks/src/daemon-client.ts
+++ b/.claude/hooks/src/daemon-client.ts
@@ -189,6 +189,9 @@ export interface DaemonResponse {
   // Track response fields
   hook?: string;
   total_invocations?: number;
+  // Imports/importers response fields
+  imports?: any[];
+  importers?: any[];
 }
 
 /**

--- a/.claude/hooks/src/tldr-read-enforcer.ts
+++ b/.claude/hooks/src/tldr-read-enforcer.ts
@@ -10,8 +10,8 @@
  */
 
 import { readFileSync, existsSync, statSync } from 'fs';
-import { basename, extname } from 'path';
-import { queryDaemonSync, DaemonResponse, trackHookActivitySync } from './daemon-client';
+import { basename, extname, resolve } from 'path';
+import { queryDaemonSync, DaemonResponse, trackHookActivitySync } from './daemon-client.js';
 
 // Search context from smart-search-router
 interface SearchContext {
@@ -371,7 +371,12 @@ async function main() {
     return;
   }
 
-  const filePath = input.tool_input.file_path || '';
+  const rawFilePath = input.tool_input.file_path || '';
+  // resolve() guarantees an absolute path: if rawFilePath is already absolute it returns
+  // it as-is; if relative, it resolves against projectCwd. Falls back to process.cwd()
+  // if input.cwd is absent (hook spec guarantees it, but be defensive).
+  const projectCwd = input.cwd || process.cwd();
+  const filePath = resolve(projectCwd, rawFilePath);
 
   // Allow non-code files
   if (!isCodeFile(filePath)) {

--- a/.claude/hooks/tsconfig.json
+++ b/.claude/hooks/tsconfig.json
@@ -15,5 +15,5 @@
         "types": ["node"]
     },
     "include": ["src/**/*.ts"],
-    "exclude": ["node_modules", "dist"]
+    "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
## Problem

The hook checks the file size with `statSync(filePath)` to decide whether to intercept a Read. But `statSync` needs an absolute path — if Claude passes a relative path like `src/api/foo.ts`, the hook's process has a different working directory than the project, so `statSync` can't find the file.

It throws, the `catch {}` block silently returns `{}`, and the raw file is read normally — TLDR never kicks in for any relative path.

## Fix

Convert relative paths to absolute using `input.cwd` (the project directory Claude Code provides in the hook payload):

```typescript
const rawFilePath = input.tool_input.file_path || '';
const filePath = isAbsolute(rawFilePath) ? rawFilePath : join(input.cwd, rawFilePath);
```

## Also fixes pre-existing TypeScript compile errors

- `daemon-client` import missing `.js` extension — required by NodeNext module resolution
- `DaemonResponse` interface missing `imports`/`importers` fields — used in `importsDaemon()` at line 906 but not declared, causing `TS2339`
- `tsconfig.json` now excludes `src/__tests__` — test files need jest/vitest types not present in the main tsconfig, causing spurious build errors

## Testing

Verified that after this fix, reading a file via relative path (e.g. `src/api/estimateSwap.ts`) correctly triggers the TLDR context instead of falling through to a raw read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path resolution and normalization to ensure input files are located and processed reliably.

* **Chores**
  * Updated build configuration to exclude test sources from compilation.
  * Expanded response structure to include additional optional metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->