### PR TITLE
Fix: copy .claude/scripts/ root files during install

### DIFF
--- a/opc/scripts/setup/claude_integration.py
+++ b/opc/scripts/setup/claude_integration.py
@@ -431,6 +431,30 @@ def _copy_scripts(opc_source: Path, target_dir: Path) -> int:
     return count
 
 
+def _copy_dotfile_scripts(opc_source: Path, target_dir: Path) -> int:
+    """Copy root-level scripts from .claude/scripts/ (e.g. status.py).
+
+    _copy_scripts() handles opc/scripts/ subdirs and ROOT_SCRIPTS.
+    This handles the .claude/scripts/ root files that settings.json
+    references directly (e.g. statusLine -> status.py).
+    """
+    count = 0
+    src_scripts = opc_source / "scripts"
+    dst_scripts = target_dir / "scripts"
+
+    if not src_scripts.exists():
+        return count
+
+    dst_scripts.mkdir(parents=True, exist_ok=True)
+
+    for script in src_scripts.iterdir():
+        if script.is_file() and script.suffix in (".py", ".sh"):
+            shutil.copy2(script, dst_scripts / script.name)
+            count += 1
+
+    return count
+
+
 def install_opc_integration(
     target_dir: Path,
     opc_source: Path,
@@ -538,6 +562,9 @@ def install_opc_integration(
 
         # Copy scripts (core, math, tldr directories + root scripts)
         result["installed_scripts"] = _copy_scripts(opc_source, target_dir)
+
+        # Copy root scripts from .claude/scripts/ (e.g. status.py for statusLine)
+        result["installed_scripts"] += _copy_dotfile_scripts(opc_source, target_dir)
 
         # Merge user items if requested
         if merge_user_items and existing and conflicts:
@@ -669,6 +696,9 @@ def install_opc_integration_symlink(
 
         # Copy scripts (core, math, tldr directories + root scripts)
         _copy_scripts(opc_source, target_dir)
+
+        # Copy root scripts from .claude/scripts/ (e.g. status.py for statusLine)
+        _copy_dotfile_scripts(opc_source, target_dir)
 
         result["success"] = True
 

--- a/opc/scripts/setup/wizard.py
+++ b/opc/scripts/setup/wizard.py
@@ -740,6 +740,7 @@ async def run_setup_wizard() -> None:
                 console.print(f"  [green]OK[/green] Installed {result['installed_rules']} rules")
                 console.print(f"  [green]OK[/green] Installed {result['installed_agents']} agents")
                 console.print(f"  [green]OK[/green] Installed {result['installed_servers']} MCP servers")
+                console.print(f"  [green]OK[/green] Installed {result['installed_scripts']} scripts")
                 if result["merged_items"]:
                     console.print(
                         f"  [green]OK[/green] Merged {len(result['merged_items'])} custom items"
@@ -802,6 +803,7 @@ async def run_setup_wizard() -> None:
                 console.print(f"  [green]OK[/green] Installed {result['installed_rules']} rules")
                 console.print(f"  [green]OK[/green] Installed {result['installed_agents']} agents")
                 console.print(f"  [green]OK[/green] Installed {result['installed_servers']} MCP servers")
+                console.print(f"  [green]OK[/green] Installed {result['installed_scripts']} scripts")
 
                 # Build TypeScript hooks
                 console.print("  Building TypeScript hooks...")


### PR DESCRIPTION
## Summary

- `.claude/scripts/` root files (e.g. `status.py`, `status.sh`, `tldr_stats.py`) are never copied to `~/.claude/scripts/` during fresh install, breaking `statusLine` which references `status.py`
- `_copy_scripts()` only handles `opc/scripts/` (different source tree) — `.claude/scripts/` root files were missed
- Wizard never reports scripts install count (silent failure)

## Changes

- **New `_copy_dotfile_scripts()`** — copies root-level `.py`/`.sh` files from `.claude/scripts/` to target
- Called in both `install_opc_integration()` and `install_opc_integration_symlink()`
- Added missing `"Installed N scripts"` print line in wizard (both code paths)

## Why this approach

| Option | Verdict |
|--------|---------|
| Add to `ROOT_SCRIPTS` | Won't work — `ROOT_SCRIPTS` maps `opc/scripts/`, not `.claude/scripts/` |
| Copytree whole `.claude/scripts/` | Conflicts with `_copy_scripts()` subdirs |
| **New `_copy_dotfile_scripts()`** | Clean, no overlap with existing `_copy_scripts()`, mirrors existing pattern |

Zero overlap between the two functions — `_copy_scripts()` handles subdirs + named root files from `opc/scripts/`, while `_copy_dotfile_scripts()` handles root-level files from `.claude/scripts/`.

## Test plan

- [ ] Fresh install (option 2): verify `~/.claude/scripts/status.py` exists
- [ ] Symlink install (option 3): verify `status.py` is copied
- [ ] Wizard output now shows `OK Installed N scripts`
- [ ] Status line works: `echo '{}' | python3 ~/.claude/scripts/status.py`

Fixes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup wizard now displays the total count of installed scripts during installation, providing enhanced visibility into the setup process.

* **Improvements**
  * Installation process now includes root-level scripts in addition to core scripts, expanding the set of utilities available after setup completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->