### PR TITLE
fix: port ensureMemoryDaemon to TypeScript session-start hook

### DIFF
--- a/.claude/hooks/dist/session-start-continuity.mjs
+++ b/.claude/hooks/dist/session-start-continuity.mjs
@@ -1,7 +1,8 @@
 // src/session-start-continuity.ts
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
-import { execSync } from "child_process";
+import { execSync, spawn } from "child_process";
 function buildHandoffDirName(sessionName, sessionId) {
   const uuidShort = sessionId.replace(/-/g, "").slice(0, 8);
   return `${sessionName}-${uuidShort}`;
@@ -157,6 +158,62 @@ function getUnmarkedHandoffs() {
     });
   } catch (error) {
     return [];
+  }
+}
+function ensureMemoryDaemon() {
+  const pidFile = path.join(os.homedir(), ".claude", "memory-daemon.pid");
+  if (fs.existsSync(pidFile)) {
+    try {
+      const pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
+      if (!isNaN(pid)) {
+        try {
+          process.kill(pid, 0);
+          return null;
+        } catch {
+        }
+      }
+    } catch {
+    }
+    try {
+      fs.unlinkSync(pidFile);
+    } catch {
+    }
+  }
+  const hookDir = path.dirname(new URL(import.meta.url).pathname);
+  const possibleLocations = [
+    // 1. Relative to compiled hook (development: .claude/hooks/dist/ → opc/scripts/core/)
+    path.resolve(hookDir, "..", "..", "..", "opc", "scripts", "core", "memory_daemon.py"),
+    // 2. In .claude/scripts/core/ (wizard-installed)
+    path.resolve(hookDir, "..", "scripts", "core", "memory_daemon.py"),
+    // 3. Global ~/.claude/scripts/core/
+    path.join(os.homedir(), ".claude", "scripts", "core", "memory_daemon.py")
+  ];
+  let daemonScript = null;
+  for (const loc of possibleLocations) {
+    if (fs.existsSync(loc)) {
+      daemonScript = loc;
+      break;
+    }
+  }
+  if (!daemonScript) {
+    console.error("Warning: memory_daemon.py not found, cannot auto-start memory daemon");
+    return null;
+  }
+  try {
+    const cwd = path.resolve(daemonScript, "..", "..", "..");
+    const logFile = path.join(os.homedir(), ".claude", "memory-daemon.log");
+    const logFd = fs.openSync(logFile, "a");
+    const child = spawn("uv", ["run", daemonScript, "start"], {
+      cwd,
+      stdio: ["ignore", logFd, logFd],
+      detached: true
+    });
+    child.unref();
+    fs.closeSync(logFd);
+    return "Memory daemon: Started";
+  } catch (e) {
+    console.error(`Warning: Failed to start memory daemon: ${e}`);
+    return null;
   }
 }
 async function main() {
@@ -374,6 +431,10 @@ All handoffs in ${handoffDir}:
       }
     }
   }
+  const daemonStatus = ensureMemoryDaemon();
+  if (daemonStatus) {
+    console.error(`\u2713 ${daemonStatus}`);
+  }
   const output = { result: "continue" };
   if (message) {
     output.message = message;
@@ -388,10 +449,10 @@ All handoffs in ${handoffDir}:
   console.log(JSON.stringify(output));
 }
 async function readStdin() {
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     let data = "";
     process.stdin.on("data", (chunk) => data += chunk);
-    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("end", () => resolve2(data));
   });
 }
 main().catch(console.error);

--- a/.claude/hooks/src/session-start-continuity.ts
+++ b/.claude/hooks/src/session-start-continuity.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 
 interface SessionStartInput {
   type?: 'startup' | 'resume' | 'clear' | 'compact';  // Legacy field
@@ -308,6 +309,82 @@ function getUnmarkedHandoffs(): UnmarkedHandoff[] {
   }
 }
 
+/**
+ * Start global memory extraction daemon if not running.
+ *
+ * The memory daemon monitors for stale sessions (heartbeat > 5 min)
+ * and automatically extracts learnings when sessions end.
+ *
+ * Returns status message or null if daemon was already running.
+ */
+function ensureMemoryDaemon(): string | null {
+  const pidFile = path.join(os.homedir(), '.claude', 'memory-daemon.pid');
+
+  // Check if already running
+  if (fs.existsSync(pidFile)) {
+    try {
+      const pid = parseInt(fs.readFileSync(pidFile, 'utf-8').trim(), 10);
+      if (!isNaN(pid)) {
+        // Check if process exists (kill -0)
+        try {
+          process.kill(pid, 0);
+          return null; // Already running
+        } catch {
+          // Process not found — stale PID file
+        }
+      }
+    } catch {
+      // Can't read PID file
+    }
+    // Remove stale PID file
+    try { fs.unlinkSync(pidFile); } catch { /* ignore */ }
+  }
+
+  // Find daemon script
+  const hookDir = path.dirname(new URL(import.meta.url).pathname);
+  const possibleLocations = [
+    // 1. Relative to compiled hook (development: .claude/hooks/dist/ → opc/scripts/core/)
+    path.resolve(hookDir, '..', '..', '..', 'opc', 'scripts', 'core', 'memory_daemon.py'),
+    // 2. In .claude/scripts/core/ (wizard-installed)
+    path.resolve(hookDir, '..', 'scripts', 'core', 'memory_daemon.py'),
+    // 3. Global ~/.claude/scripts/core/
+    path.join(os.homedir(), '.claude', 'scripts', 'core', 'memory_daemon.py'),
+  ];
+
+  let daemonScript: string | null = null;
+  for (const loc of possibleLocations) {
+    if (fs.existsSync(loc)) {
+      daemonScript = loc;
+      break;
+    }
+  }
+
+  if (!daemonScript) {
+    console.error('Warning: memory_daemon.py not found, cannot auto-start memory daemon');
+    return null;
+  }
+
+  try {
+    // cwd = opc/ directory (3 levels up from the script)
+    const cwd = path.resolve(daemonScript, '..', '..', '..');
+    const logFile = path.join(os.homedir(), '.claude', 'memory-daemon.log');
+
+    const logFd = fs.openSync(logFile, 'a');
+    const child = spawn('uv', ['run', daemonScript, 'start'], {
+      cwd,
+      stdio: ['ignore', logFd, logFd],
+      detached: true,
+    });
+    child.unref();
+    fs.closeSync(logFd);
+
+    return 'Memory daemon: Started';
+  } catch (e) {
+    console.error(`Warning: Failed to start memory daemon: ${e}`);
+    return null;
+  }
+}
+
 async function main() {
   const input: SessionStartInput = JSON.parse(await readStdin());
   const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
@@ -555,6 +632,12 @@ async function main() {
       }
       // For startup without ledger, stay silent (normal case)
     }
+  }
+
+  // Ensure memory daemon is running (auto-extracts learnings from ended sessions)
+  const daemonStatus = ensureMemoryDaemon();
+  if (daemonStatus) {
+    console.error(`✓ ${daemonStatus}`);
   }
 
   // Output with proper format per Claude Code docs


### PR DESCRIPTION
## Summary

- Port `ensure_memory_daemon()` from the dead Python hook to the registered TypeScript hook
- Memory daemon now auto-starts on every session start (was never starting)
- `archival_memory` table will actually populate with extracted learnings

## Root Cause

`ensure_memory_daemon()` existed in `session_start_continuity.py` (Python) but `settings.json` registers `session-start-continuity.mjs` (TypeScript) which had zero memory/daemon logic. Dead code since initial release `f8d7173`.

## Changes

- **`session-start-continuity.ts`** — add `ensureMemoryDaemon()` function + call it in `main()`
- **`session-start-continuity.mjs`** — rebuilt dist

## Improvements over Python version

| Aspect | Python (dead) | TypeScript (new) |
|--------|---------------|------------------|
| stderr | `DEVNULL` (swallowed) | Logs to `~/.claude/memory-daemon.log` |
| Script not found | Silent `return None` | `console.error` warning |
| Daemonization | `subprocess.Popen` | `spawn()` with `detached` + `unref()` |

## Test plan

- [ ] Start fresh session → verify `memory-daemon.pid` created
- [ ] `kill -0 $(cat ~/.claude/memory-daemon.pid)` → process alive
- [ ] Start second session → daemon NOT restarted (already running)
- [ ] Kill daemon, start session → daemon auto-restarts
- [ ] Check `~/.claude/memory-daemon.log` has startup output

Fixes #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory daemon is now automatically started during application startup to improve background service availability.

* **Bug Fixes**
  * Better handling of missing or stale daemon state to prevent startup failures.
  * Improved resilience when background services are unavailable; app now logs status without crashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->