### PR TITLE
feat: add block-no-verify hook to prevent bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,15 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Closes #163

This PR adds the block-no-verify package as a PreToolUse Bash hook in .claude/settings.json to prevent Claude Code agents from bypassing git hooks.

**What changed**

Added a new Bash-scoped PreToolUse hook entry that runs block-no-verify@1.1.2 before every Bash tool call. This exits non-zero if a git hook bypass flag is detected, causing Claude Code to reject the command.

**Why**

Continuous Claude already embraces shift-left validation: hooks run pyright/ruff after edits to catch errors early. This extends the same philosophy to commits: block hook-bypass flags before they can silently corrupt history integrity.

In multi-agent orchestration scenarios where agents run autonomously across sessions, this guard prevents an agent from committing code that bypasses linting, type checking, or commit signing — all without any human review.

**About block-no-verify**

block-no-verify (https://github.com/tupe12334/block-no-verify) is MIT licensed, has zero runtime dependencies, and works with Node.js/npx at version 1.1.2.

_Disclosure: I am the author and maintainer of block-no-verify._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration for command execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->